### PR TITLE
Fix: Resolve Jekyll theme loading issue for GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "jekyll"
-gem "minimal-mistakes-jekyll"
+gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-theme: minimal-mistakes-jekyll
+remote_theme: mmistakes/minimal-mistakes
 title: "My Awesome Blog"
 author: "Your Name"
 description: "A blog about interesting things."


### PR DESCRIPTION
The minimal-mistakes-jekyll theme was not being found during GitHub Pages builds.

This commit addresses the issue by:
1. Modifying the Gemfile to use `gem "github-pages", group: :jekyll_plugins`. This allows GitHub Pages to manage Jekyll and its theme dependencies, which is the recommended approach. The direct `gem "minimal-mistakes-jekyll"` was removed.
2. Updating `_config.yml` to use `remote_theme: mmistakes/minimal-mistakes`. This instructs Jekyll to fetch the theme directly from its GitHub repository, ensuring greater compatibility and reliability with GitHub Pages.

These changes should allow the Jekyll site to build correctly on GitHub Pages using the Minimal Mistakes theme.