### PR TITLE
It looks like you're working on a fix to resolve an `include_cached` …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "jekyll"
 gem "github-pages", group: :jekyll_plugins
+gem "jekyll-include-cache", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ description: "A blog about interesting things."
 url: "https://diepdaocs.github.io"
 baseurl: "/blog"
 repository: "diepdaocs/blog"
+plugins:
+  - jekyll-include-cache


### PR DESCRIPTION
…error and some dependency conflicts.

This involves making some adjustments to address the 'Unknown tag include_cached' error and potential Gemfile dependency issues when building with GitHub Pages.

Here's what I see in the changes:
- In your Gemfile:
  - You've removed the explicit `gem "jekyll"`. The `github-pages` gem will manage the Jekyll version.
  - You've added `gem "jekyll-include-cache", group: :jekyll_plugins` to ensure the plugin providing the `include_cached` tag is explicitly available to the GitHub Pages build environment.
- In your _config.yml:
  - You've added `jekyll-include-cache` to the `plugins` array to ensure Jekyll attempts to load it.

These changes should help provide a cleaner dependency definition for GitHub Pages and ensure that the necessary plugin for `include_cached` (used by the Minimal Mistakes theme) is correctly loaded.