### PR TITLE
Refactor: Update baseurl to serve site from root

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: "My Awesome Blog"
 author: "Your Name"
 description: "A blog about interesting things."
 url: "https://diepdaocs.github.io"
-baseurl: "/blog"
+baseurl: ""
 repository: "diepdaocs/blog"
 plugins:
   - jekyll-include-cache


### PR DESCRIPTION
I changed `baseurl` in `_config.yml` from "/blog" to an empty string (""). This modification allows the Jekyll site to be served directly from the root of the domain (e.g., `https://username.github.io/`) rather than a subpath.

The `url` setting remains `https://diepdaocs.github.io`.