### PR TITLE
Refactor: Remove explicit H1 from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
 layout: home
 ---
-# Welcome to my personal space on the web!
 
-I'm glad you're here. Feel free to explore my latest [posts](./_posts/) or get to know more [about me](./about/).
+Explore my latest [posts](./_posts/) or get to know more [about me](./about/).


### PR DESCRIPTION
To investigate the duplicate welcome message, this commit removes the H1 heading and introductory paragraph from index.md.

This will help determine if the theme's 'home' layout is adding its own title, which would then allow for a more targeted fix to the duplication issue.