### PR TITLE
Apply consistent font sizes across post lists

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -122,7 +122,7 @@ $header-font-family: $serif;
 .home-grid__right { grid-area: right; }
 
 /* Smaller, elegant post titles on home feed */
-.home-grid__posts {
+.home-grid__posts, .archive {
   .archive__item-title {
     font-size: 1.0em;
     line-height: 1.4;
@@ -154,7 +154,7 @@ $header-font-family: $serif;
     padding: 0.75rem 0.75rem;
     gap: 1rem;
   }
-  .home-grid__posts {
+  .home-grid__posts, .archive {
     .archive__item-title { font-size: 0.95em; }
     .archive__item-excerpt { font-size: 0.82em; }
   }


### PR DESCRIPTION
Updates the `assets/css/main.scss` file to apply the same font size rules from `.home-grid__posts` (the home page post list) to the `.archive` class (which is used for the Posts, Categories, and Tags pages). Includes updates for the mobile breakpoint.

---
*PR created automatically by Jules for task [16347076753229277589](https://jules.google.com/task/16347076753229277589) started by @diepdaocs*