### PR TITLE
Fix Footer and Masthead Links and Navigation

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-_site
+_site/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ author:
       icon: "fab fa-fw fa-github"
       url: "https://github.com/diepdaocs"
 url: "https://diepdaocs.github.io"
+copyright_url: "/blog/about/"
 baseurl: "/blog"
 repository: "diepdaocs/blog"
 collections:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,5 @@ main:
     url: /tags/
   - title: "About"
     url: /about/
+  - title: "GitHub"
+    url: "https://github.com/diepdaocs?tab=repositories"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -17,7 +17,7 @@
       <!-- RIGHT: Nav items (collapse on small screens) + theme switcher -->
       <div class="masthead__right">
         <nav id="site-nav" class="greedy-nav">
-          <a class="site-title" href="{{ '/' | relative_url }}" style="display:none">Diep Dao</a>
+          <a class="site-title" href="{{ '/about/' | relative_url }}" style="display:none">Diep Dao</a>
           <ul class="visible-links">
             {%- for link in site.data.navigation.main -%}
               <li class="masthead__menu-item">


### PR DESCRIPTION
- Changed copyright_url in `_config.yml` to point to the About page.
- Updated `masthead.html` to point `site-title` link to `/about/`.
- Added GitHub link to `_data/navigation.yml`.
- Added `_site/` and `vendor/` to `.gitignore`.

---
*PR created automatically by Jules for task [4881760150831306923](https://jules.google.com/task/4881760150831306923) started by @diepdaocs*