### PR TITLE
Organize journey articles together and add series references to welcome posts

### DIFF
--- a/_posts/2026-02-27-personal-journey-1-ha-tinh.md
+++ b/_posts/2026-02-27-personal-journey-1-ha-tinh.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 1: The Village"
-date: 2026-02-27 09:00:00 +0800
+date: 2026-02-27 09:25:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-journey-2-tay-nguyen.md
+++ b/_posts/2026-02-27-personal-journey-2-tay-nguyen.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 2: Following My Uncle to the Highlands"
-date: 2026-02-27 09:05:00 +0800
+date: 2026-02-27 09:30:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-journey-3-school-and-coffee.md
+++ b/_posts/2026-02-27-personal-journey-3-school-and-coffee.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 3: School, Coffee, and Learning to Want More"
-date: 2026-02-27 09:10:00 +0800
+date: 2026-02-27 09:35:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-journey-4-high-school.md
+++ b/_posts/2026-02-27-personal-journey-4-high-school.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 4: Coming Home, and Leaving Again"
-date: 2026-02-27 09:15:00 +0800
+date: 2026-02-27 09:40:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-journey-5-ho-chi-minh.md
+++ b/_posts/2026-02-27-personal-journey-5-ho-chi-minh.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 5: Ho Chi Minh City and the Beginning of Everything"
-date: 2026-02-27 09:20:00 +0800
+date: 2026-02-27 09:45:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-singapore.md
+++ b/_posts/2026-02-27-personal-singapore.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 7: Singapore, Family, and Finding My Ground"
-date: 2026-02-27 09:30:00 +0800
+date: 2026-02-27 09:55:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-personal-university-and-first-career.md
+++ b/_posts/2026-02-27-personal-university-and-first-career.md
@@ -1,7 +1,7 @@
 ---
 layout: single
 title: "My Journey — Part 6: University, a Japanese Company, and the Man Who Changed Everything"
-date: 2026-02-27 09:25:00 +0800
+date: 2026-02-27 09:50:00 +0800
 categories:
   - personal
 tags:

--- a/_posts/2026-02-27-welcome-to-ai.md
+++ b/_posts/2026-02-27-welcome-to-ai.md
@@ -28,3 +28,8 @@ This series covers AI and Machine Learning from both a practical and conceptual 
 AI is not magic, and it's not going to replace good engineering judgment. The most impactful work I've done has always come from combining solid ML knowledge with strong software engineering practices — understanding the data, designing reliable pipelines, and knowing when *not* to use a complex model.
 
 I'll be writing from that perspective: practical, grounded, and honest about the trade-offs.
+
+## Articles in This Series
+
+- [How Andrew Ng's Courses Changed the Way I Think About AI](/blog/ai/2026/02/27/learning-ml-andrew-ng.html)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-blockchain.md
+++ b/_posts/2026-02-27-welcome-to-blockchain.md
@@ -27,3 +27,8 @@ I'll be exploring blockchain from an engineer's perspective:
 I hold a Blockchain Specialization certificate and have worked on cryptography and smart contract development for DeFi and tokenized assets. But beyond the credentials, what keeps me interested is the intersection of computer science, cryptography, and economics — three fields I find endlessly fascinating.
 
 This series is for developers who want to understand what's actually happening under the hood.
+
+## Articles in This Series
+
+- [Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger](/blog/blockchain/2026/02/27/blockchain-introduction.html)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-finance.md
+++ b/_posts/2026-02-27-welcome-to-finance.md
@@ -27,3 +27,7 @@ This series sits at the intersection of finance and engineering:
 Most software engineers don't need to understand finance deeply. But if you're building systems where money moves — whether that's a trading platform, a payments app, or a DeFi protocol — understanding the financial context makes you a dramatically better engineer.
 
 That's the angle I'll be writing from: a software engineer who had to learn finance on the job, and found it far more interesting than expected.
+
+## Articles in This Series
+
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)


### PR DESCRIPTION
- Shift timestamps of all 7 My Journey articles (09:25–09:55) so they form a
  contiguous block, separate from the welcome posts (09:00–09:20) and technical
  articles (10:00+)
- Add "Articles in This Series" section to welcome-to-ai.md with links to the
  Andrew Ng review and AI & Blockchain post
- Add "Articles in This Series" section to welcome-to-blockchain.md with links
  to the Blockchain From First Principles and AI & Blockchain post
- Add "Articles in This Series" section to welcome-to-finance.md with a link
  to the AI & Blockchain post (fintech angle)

https://claude.ai/code/session_01PM7qBWHRZVQ4fdWJHuMMqv