### PR TITLE
Enable Giscus comments on posts and home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,21 @@ url: "https://diepdaocs.github.io"
 copyright_url: "/blog/about/"
 baseurl: "/blog"
 repository: "diepdaocs/blog"
+
+comments:
+  provider: "giscus"
+  giscus:
+    repo:              "diepdaocs/blog"
+    repo_id:           "REPLACE_WITH_REPO_ID"
+    category:          "Comments"
+    category_id:       "REPLACE_WITH_CATEGORY_ID"
+    mapping:           "pathname"
+    reactions_enabled: "1"
+    emit_metadata:     "0"
+    input_position:    "top"
+    theme:             "preferred_color_scheme"
+    lang:              "en"
+    lazy:              true
 collections:
   pages:
     output: true
@@ -29,6 +44,11 @@ defaults:
       path: "_pages"
     values:
       layout: single
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      comments: true
 
 after_footer_scripts:
   - /assets/js/theme-switch.js

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,3 +24,24 @@ layout: default
   </aside>
 
 </div>
+
+{% if site.comments.provider == "giscus" %}
+<section class="home-comments">
+  <h3 class="archive__subtitle">Comments</h3>
+  <script src="https://giscus.app/client.js"
+    data-repo="{{ site.comments.giscus.repo }}"
+    data-repo-id="{{ site.comments.giscus.repo_id }}"
+    data-category="{{ site.comments.giscus.category }}"
+    data-category-id="{{ site.comments.giscus.category_id }}"
+    data-mapping="{{ site.comments.giscus.mapping | default: 'pathname' }}"
+    data-reactions-enabled="{{ site.comments.giscus.reactions_enabled | default: '1' }}"
+    data-emit-metadata="{{ site.comments.giscus.emit_metadata | default: '0' }}"
+    data-input-position="{{ site.comments.giscus.input_position | default: 'top' }}"
+    data-theme="{{ site.comments.giscus.theme | default: 'preferred_color_scheme' }}"
+    data-lang="{{ site.comments.giscus.lang | default: 'en' }}"
+    {% if site.comments.giscus.lazy %}data-loading="lazy"{% endif %}
+    crossorigin="anonymous"
+    async>
+  </script>
+</section>
+{% endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -477,6 +477,11 @@ $dk-code:         #0d0d0d;
     &.active { background: $dk-link; color: #fff; }
   }
 
+  // Home page comments
+  .home-comments {
+    h3 { color: $dk-heading; }
+  }
+
   // Timeline nav blocks in personal posts
   div[style*="background:#f8f9fa"] {
     background: $dk-surface !important;
@@ -485,4 +490,11 @@ $dk-code:         #0d0d0d;
     a { color: $dk-link !important; &:hover { color: $dk-link-hover !important; } }
     strong { color: $dk-heading !important; }
   }
+}
+
+/* ── Home page comments section ────────────────────── */
+.home-comments {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 1.5rem 1rem;
 }

--- a/assets/js/theme-switch.js
+++ b/assets/js/theme-switch.js
@@ -15,6 +15,14 @@
     } else {
       document.documentElement.removeAttribute('data-theme');
     }
+    // Sync Giscus comment widget theme
+    var giscusFrame = document.querySelector('iframe.giscus-frame');
+    if (giscusFrame) {
+      giscusFrame.contentWindow.postMessage(
+        { giscus: { setConfig: { theme: theme === 'dark' ? 'dark' : 'light' } } },
+        'https://giscus.app'
+      );
+    }
   }
 
   function updateButton(theme) {


### PR DESCRIPTION
Add GitHub Discussions-based commenting via Giscus — no database needed.
Posts automatically get comments via Minimal Mistakes built-in support.
Home page gets a manually embedded Giscus widget below the post grid.
Dark mode toggle syncs the Giscus iframe theme via postMessage.

Note: repo_id and category_id in _config.yml must be replaced with
values from https://giscus.app after enabling GitHub Discussions.

https://claude.ai/code/session_01V2W6D1PbYMPibVdgp6iGcw