### PR TITLE
Fix broken reference URLs in posts to support both domains

### DIFF
--- a/_posts/2026-02-27-personal-journey-1-ha-tinh.md
+++ b/_posts/2026-02-27-personal-journey-1-ha-tinh.md
@@ -15,12 +15,12 @@ tags:
   <strong>My Journey — Full Series</strong>
   <ol style="margin:10px 0 0 0; padding-left:20px;">
     <li><strong>The Village — Ha Tinh ← you are here</strong></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-university-and-first-career.html">University, a Japanese Company, and the Man Who Changed Everything</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-singapore.html">Singapore, Family, and Finding My Ground</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-university-and-first-career.html">University, a Japanese Company, and the Man Who Changed Everything</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-singapore.html">Singapore, Family, and Finding My Ground</a></li>
   </ol>
 </div>
 

--- a/_posts/2026-02-27-personal-journey-2-tay-nguyen.md
+++ b/_posts/2026-02-27-personal-journey-2-tay-nguyen.md
@@ -12,7 +12,7 @@ tags:
   - journey
 ---
 
-*Part 2 of my personal journey series. [Read Part 1 here.](/blog/personal/2026/02/27/personal-journey-1-ha-tinh.html)*
+*Part 2 of my personal journey series. [Read Part 1 here.]({{ site.baseurl }}/personal/2026/02/27/personal-journey-1-ha-tinh.html)*
 
 ---
 

--- a/_posts/2026-02-27-personal-journey-3-school-and-coffee.md
+++ b/_posts/2026-02-27-personal-journey-3-school-and-coffee.md
@@ -12,7 +12,7 @@ tags:
   - journey
 ---
 
-*Part 3 of my personal journey series. [Read Part 2 here.](/blog/personal/2026/02/27/personal-journey-2-tay-nguyen.html)*
+*Part 3 of my personal journey series. [Read Part 2 here.]({{ site.baseurl }}/personal/2026/02/27/personal-journey-2-tay-nguyen.html)*
 
 ---
 

--- a/_posts/2026-02-27-personal-journey-4-high-school.md
+++ b/_posts/2026-02-27-personal-journey-4-high-school.md
@@ -11,7 +11,7 @@ tags:
   - journey
 ---
 
-*Part 4 of my personal journey series. [Read Part 3 here.](/blog/personal/2026/02/27/personal-journey-3-school-and-coffee.html)*
+*Part 4 of my personal journey series. [Read Part 3 here.]({{ site.baseurl }}/personal/2026/02/27/personal-journey-3-school-and-coffee.html)*
 
 ---
 

--- a/_posts/2026-02-27-personal-journey-5-ho-chi-minh.md
+++ b/_posts/2026-02-27-personal-journey-5-ho-chi-minh.md
@@ -12,7 +12,7 @@ tags:
   - journey
 ---
 
-*Part 5 of my personal journey series. [Read Part 4 here.](/blog/personal/2026/02/27/personal-journey-4-high-school.html)*
+*Part 5 of my personal journey series. [Read Part 4 here.]({{ site.baseurl }}/personal/2026/02/27/personal-journey-4-high-school.html)*
 
 ---
 

--- a/_posts/2026-02-27-personal-singapore.md
+++ b/_posts/2026-02-27-personal-singapore.md
@@ -14,19 +14,19 @@ tags:
   - journey
 ---
 
-*Part 7 of my personal journey series. [Read Part 6 here.](/blog/personal/2026/02/27/personal-university-and-first-career.html)*
+*Part 7 of my personal journey series. [Read Part 6 here.]({{ site.baseurl }}/personal/2026/02/27/personal-university-and-first-career.html)*
 
 ---
 
 <div style="background:#f8f9fa; border-left:4px solid #add8e6; padding:16px 20px; margin-bottom:32px; border-radius:4px;">
   <strong>My Journey — Full Series</strong>
   <ol style="margin:10px 0 0 0; padding-left:20px;">
-    <li><a href="/blog/personal/2026/02/27/personal-journey-1-ha-tinh.html">The Village — Ha Tinh</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-university-and-first-career.html">University, a Japanese Company, and the Man Who Changed Everything</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-1-ha-tinh.html">The Village — Ha Tinh</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-university-and-first-career.html">University, a Japanese Company, and the Man Who Changed Everything</a></li>
     <li><strong>Singapore, Family, and Finding My Ground ← you are here</strong></li>
   </ol>
 </div>

--- a/_posts/2026-02-27-personal-university-and-first-career.md
+++ b/_posts/2026-02-27-personal-university-and-first-career.md
@@ -22,13 +22,13 @@ tags:
 <div style="background:#f8f9fa; border-left:4px solid #add8e6; padding:16px 20px; margin-bottom:32px; border-radius:4px;">
   <strong>My Journey — Full Series</strong>
   <ol style="margin:10px 0 0 0; padding-left:20px;">
-    <li><a href="/blog/personal/2026/02/27/personal-journey-1-ha-tinh.html">The Village — Ha Tinh</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
-    <li><a href="/blog/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-1-ha-tinh.html">The Village — Ha Tinh</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-2-tay-nguyen.html">Following My Uncle to the Highlands</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-3-school-and-coffee.html">School, Coffee, and Learning to Want More</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-4-high-school.html">Coming Home, and Leaving Again</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-journey-5-ho-chi-minh.html">Ho Chi Minh City and the Beginning of Everything</a></li>
     <li><strong>University, a Japanese Company, and the Man Who Changed Everything ← you are here</strong></li>
-    <li><a href="/blog/personal/2026/02/27/personal-singapore.html">Singapore, Family, and Finding My Ground</a></li>
+    <li><a href="{{ site.baseurl }}/personal/2026/02/27/personal-singapore.html">Singapore, Family, and Finding My Ground</a></li>
   </ol>
 </div>
 

--- a/_posts/2026-02-27-welcome-to-ai.md
+++ b/_posts/2026-02-27-welcome-to-ai.md
@@ -31,5 +31,5 @@ I'll be writing from that perspective: practical, grounded, and honest about the
 
 ## Articles in This Series
 
-- [How Andrew Ng's Courses Changed the Way I Think About AI](/blog/ai/2026/02/27/learning-ml-andrew-ng.html)
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [How Andrew Ng's Courses Changed the Way I Think About AI]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng.html)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-blockchain.md
+++ b/_posts/2026-02-27-welcome-to-blockchain.md
@@ -30,5 +30,5 @@ This series is for developers who want to understand what's actually happening u
 
 ## Articles in This Series
 
-- [Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger](/blog/blockchain/2026/02/27/blockchain-introduction.html)
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction.html)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-finance.md
+++ b/_posts/2026-02-27-welcome-to-finance.md
@@ -30,4 +30,4 @@ That's the angle I'll be writing from: a software engineer who had to learn fina
 
 ## Articles in This Series
 
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know](/blog/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-personal-life.md
+++ b/_posts/2026-02-27-welcome-to-personal-life.md
@@ -40,4 +40,4 @@ But I've also found that the most meaningful connections — with colleagues, wi
 
 If any of that resonates, this section is for you.
 
-Start with [Part 1 of My Journey](/blog/personal/2026/02/27/personal-journey-1-ha-tinh.html) — a village in Ha Tinh, and the beginning of everything.
+Start with [Part 1 of My Journey]({{ site.baseurl }}/personal/2026/02/27/personal-journey-1-ha-tinh.html) — a village in Ha Tinh, and the beginning of everything.


### PR DESCRIPTION
Replace hardcoded /blog/ prefix with {{ site.baseurl }} in all post
internal links, making them compatible with both:
- diepdaocs.github.io/blog (baseurl: /blog)
- diepdao.me (baseurl: "")

https://claude.ai/code/session_019FjK12x1PFz4CPS3R9wjwN