### PR TITLE
Add Projects page with 3 portfolio project cards

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,5 +10,7 @@ main:
     url: /tags/
   - title: "About"
     url: /about/
+  - title: "Projects"
+    url: /projects/
   - title: "GitHub"
     url: "https://github.com/diepdaocs?tab=repositories"

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -1,0 +1,31 @@
+---
+layout: default
+---
+
+<div class="projects-page">
+  <header class="projects-page__header">
+    <h1 class="projects-page__title">{{ page.title }}</h1>
+    {% if page.description %}
+      <p class="projects-page__description">{{ page.description }}</p>
+    {% endif %}
+  </header>
+
+  <div class="projects-grid">
+    {% for project in page.projects %}
+      <a href="{{ project.url | relative_url }}" class="project-card">
+        <div class="project-card__image">
+          <img src="{{ project.image | relative_url }}" alt="{{ project.title }}">
+        </div>
+        <div class="project-card__body">
+          <h2 class="project-card__title">{{ project.title }}</h2>
+          <p class="project-card__excerpt">{{ project.excerpt }}</p>
+          <div class="project-card__tags">
+            {% for tag in project.tags %}
+              <span class="project-card__tag">{{ tag }}</span>
+            {% endfor %}
+          </div>
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+</div>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,36 @@
+---
+layout: projects
+title: "Projects"
+permalink: /projects/
+description: "Hands-on systems I've designed and built — spanning financial engineering, AI agents, and blockchain smart contracts."
+projects:
+  - title: "Financial Engineering & Risk Management"
+    url: /projects/financial-engineering/
+    image: /assets/images/project-finance.svg
+    excerpt: "A simulation trading system with real-time risk calculation — order books, trade matching, PnL, Greeks, and multi-asset risk dashboards powered by ClickHouse."
+    tags:
+      - Java
+      - ClickHouse
+      - Kafka
+      - Risk Engine
+
+  - title: "AI & Agents Workflow"
+    url: /projects/ai-agents-workflow/
+    image: /assets/images/project-ai-agents.svg
+    excerpt: "Text-to-SQL and text-to-dashboard agents using A2A protocol — natural language interfaces for traders to build and adjust real-time dashboards."
+    tags:
+      - LLM
+      - A2A Protocol
+      - Python
+      - NL Interface
+
+  - title: "Blockchain & Smart Contracts"
+    url: /projects/blockchain-smart-contracts/
+    image: /assets/images/project-blockchain.svg
+    excerpt: "Tokenize trading assets using Solidity and Ethereum — a smart contract creation framework for stocks, bonds, futures, and options."
+    tags:
+      - Solidity
+      - Ethereum
+      - DeFi
+      - Tokenization
+---

--- a/_posts/2026-02-28-project-ai-agents-workflow.md
+++ b/_posts/2026-02-28-project-ai-agents-workflow.md
@@ -1,0 +1,181 @@
+---
+layout: single
+title: "Project: AI & Agents Workflow — Text-to-SQL, Text-to-Dashboard"
+date: 2026-02-28 10:05:00 +0800
+permalink: /projects/ai-agents-workflow/
+categories:
+  - ai
+  - projects
+tags:
+  - llm
+  - generative-ai
+  - a2a-protocol
+  - text-to-sql
+  - agents
+  - natural-language
+---
+
+An AI agents system that lets traders create and modify dashboards using natural language — powered by Text-to-SQL and Text-to-Dashboard agents communicating via the A2A protocol.
+
+The vision: a trader types "show me PnL by desk for the last week" into a chat window, and a dashboard materializes. They say "break it down by currency pair," and the dashboard updates. No tickets, no waiting for developers.
+
+---
+
+## Overview
+
+This project builds a multi-agent system where specialized AI agents collaborate to transform natural language into working trading dashboards. It demonstrates:
+
+1. **Text2SQL Agent** — converts natural language to SQL queries against a ClickHouse trading database
+2. **Text2Dashboard Agent** — takes query results and generates dashboard configurations
+3. **A2A Protocol** — agent-to-agent communication for orchestrating the workflow
+4. **Chat Interface** — conversational UI for traders to iteratively refine dashboards
+
+---
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌──────────────┐
+│   Trader     │────▶│  Chat Interface  │────▶│  Orchestrator │
+│  (Browser)   │◀────│    (React)       │◀────│   Agent       │
+└─────────────┘     └──────────────────┘     └───────┬──────┘
+                                                      │
+                                              A2A Protocol
+                                                      │
+                              ┌────────────────────────┼─────────────────────┐
+                              │                        │                     │
+                        ┌─────▼──────┐          ┌─────▼──────┐       ┌─────▼──────┐
+                        │  Text2SQL  │          │ Text2Dash  │       │  Schema    │
+                        │   Agent    │          │   Agent    │       │  Agent     │
+                        └─────┬──────┘          └─────┬──────┘       └────────────┘
+                              │                       │
+                        ┌─────▼──────┐          ┌─────▼──────┐
+                        │ ClickHouse │          │ Dashboard  │
+                        │  (Query)   │          │  Renderer  │
+                        └────────────┘          └────────────┘
+```
+
+### Agent Roles
+
+**Orchestrator Agent**
+- Receives natural language input from the chat interface
+- Determines which agents to invoke and in what order
+- Manages conversation context and multi-turn refinement
+- Routes A2A messages between agents
+
+**Text2SQL Agent**
+- Understands the ClickHouse schema (trades, risk metrics, positions)
+- Converts natural language to valid SQL queries
+- Validates queries for safety (no mutations, resource limits)
+- Handles ambiguity by asking clarifying questions
+
+**Text2Dashboard Agent**
+- Takes SQL query results and generates dashboard configurations
+- Supports chart types: line, bar, heatmap, table, time-series
+- Adapts layout to data shape (single metric vs. multi-dimensional)
+- Generates responsive dashboard JSON consumed by the React renderer
+
+**Schema Agent**
+- Provides schema context to other agents
+- Maps business terms ("PnL," "desk," "portfolio") to table columns
+- Maintains a glossary of trading terminology
+
+---
+
+## A2A Protocol
+
+The Agent-to-Agent (A2A) protocol defines how agents communicate:
+
+```json
+{
+  "from": "orchestrator",
+  "to": "text2sql",
+  "type": "request",
+  "payload": {
+    "intent": "query",
+    "natural_language": "Show me PnL by desk for last week",
+    "context": {
+      "user_role": "fx_trader",
+      "desk": "fx_spot",
+      "previous_queries": []
+    }
+  }
+}
+```
+
+Key features:
+- **Typed messages** — request, response, clarification, error
+- **Context propagation** — conversation history travels with each message
+- **Agent discovery** — agents register capabilities, orchestrator routes accordingly
+- **Fallback chains** — if one agent can't handle a request, it's routed to the next
+
+---
+
+## Chat Interface
+
+The chat window is embedded in the trading dashboard, providing a conversational experience:
+
+**Example conversation:**
+
+> **Trader:** Show me today's PnL for the FX desk
+>
+> **Agent:** Here's the FX desk PnL for today. Total: +$1.2M. Top contributors: EUR/USD (+$450K), GBP/USD (+$280K).
+>
+> *[Dashboard appears with bar chart of PnL by currency pair]*
+>
+> **Trader:** Break it down by trader
+>
+> **Agent:** Updated — showing PnL by trader within the FX desk.
+>
+> *[Dashboard updates to show grouped bar chart: traders × currency pairs]*
+>
+> **Trader:** Add a time-series of cumulative PnL for the top 3 pairs
+>
+> **Agent:** Added a time-series panel below the bar chart.
+
+The chat maintains context across turns, so traders can iteratively refine their dashboards without starting over.
+
+---
+
+## Per-Desk Customization
+
+Different trading desks have different vocabulary, metrics, and dashboard preferences:
+
+| Desk | Key Metrics | Default Views |
+|------|-------------|---------------|
+| **FX Spot** | PnL, position, spread | Currency pair heatmap, PnL waterfall |
+| **Rates** | DV01, duration, yield | Tenor ladder, yield curve, PnL attribution |
+| **Options** | Greeks, vol surface | Greeks panel, vol smile, PnL decomposition |
+| **Credit** | Spread, default prob | Credit spread curve, issuer exposure |
+
+The agents are context-aware — when an FX trader says "show my exposure," the system knows to show currency pair positions, not bond durations.
+
+---
+
+## Technology Stack
+
+| Component | Technology | Why |
+|-----------|-----------|-----|
+| LLM | Claude / GPT-4 | Natural language understanding |
+| Agent Framework | Python, custom | Lightweight A2A orchestration |
+| Backend | FastAPI | Async API endpoints |
+| Database | ClickHouse | Fast analytical queries on trade data |
+| Dashboard | React | Dynamic chart rendering |
+| Communication | WebSocket | Real-time chat and dashboard updates |
+
+---
+
+## What You'll Learn
+
+This project demonstrates:
+- How to build a multi-agent system with clear agent responsibilities
+- The A2A protocol for agent-to-agent communication
+- Text-to-SQL techniques for financial databases
+- Natural language interfaces for non-technical users
+- Iterative dashboard creation through conversational AI
+
+---
+
+## Repository
+
+*Coming soon — the GitHub repository with full source code, agent definitions, and example conversations.*

--- a/_posts/2026-02-28-project-blockchain-smart-contracts.md
+++ b/_posts/2026-02-28-project-blockchain-smart-contracts.md
@@ -1,0 +1,207 @@
+---
+layout: single
+title: "Project: Blockchain & Smart Contracts — Tokenizing Trading Assets"
+date: 2026-02-28 10:10:00 +0800
+permalink: /projects/blockchain-smart-contracts/
+categories:
+  - blockchain
+  - projects
+tags:
+  - solidity
+  - ethereum
+  - smart-contracts
+  - tokenization
+  - defi
+---
+
+A smart contract creation framework for tokenizing traditional trading assets — stocks, bonds, futures, and options — on the Ethereum blockchain.
+
+This project bridges traditional finance and DeFi by providing a framework to represent real-world financial instruments as on-chain tokens, complete with the business logic that governs them.
+
+---
+
+## Overview
+
+Tokenization is the process of representing ownership of real-world assets as blockchain tokens. This project builds a framework that:
+
+1. **Defines token standards** for different asset classes (equities, bonds, futures, options)
+2. **Provides a factory pattern** for deploying new asset tokens
+3. **Encodes financial logic** into smart contracts (dividends, coupons, expiry, settlement)
+4. **Includes tooling** for deployment, testing, and interaction
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Token Factory                       │
+│  ┌─────────────┐ ┌─────────────┐ ┌───────────────┐ │
+│  │   Equity    │ │    Bond     │ │   Derivative  │ │
+│  │  Template   │ │  Template   │ │   Template    │ │
+│  └──────┬──────┘ └──────┬──────┘ └───────┬───────┘ │
+└─────────┼───────────────┼────────────────┼──────────┘
+          │               │                │
+    ┌─────▼──────┐  ┌─────▼──────┐  ┌─────▼──────┐
+    │ AAPL Token │  │ US10Y Bond │  │  BTC Call   │
+    │  (ERC-20)  │  │  (ERC-20)  │  │ (ERC-1155)  │
+    └────────────┘  └────────────┘  └─────────────┘
+          │               │                │
+          └───────────────┼────────────────┘
+                          │
+                  ┌───────▼───────┐
+                  │   Ethereum    │
+                  │   Network     │
+                  └───────────────┘
+```
+
+---
+
+## Asset Types & Token Standards
+
+### Equities (ERC-20)
+
+Stocks are fungible — one share of AAPL is the same as any other. ERC-20 is the natural fit.
+
+**Key features:**
+- Fractional ownership via token divisibility (18 decimals)
+- Dividend distribution through snapshot-based claims
+- Corporate actions (splits, mergers) via admin functions
+- Transfer restrictions for compliance (whitelisting)
+
+```solidity
+contract EquityToken is ERC20, Ownable {
+    string public symbol;         // e.g., "AAPL"
+    uint256 public totalShares;
+
+    // Dividend distribution
+    mapping(uint256 => uint256) public dividendPerShare;
+    uint256 public currentEpoch;
+
+    function claimDividend(uint256 epoch) external { ... }
+    function distributeDividend() external onlyOwner { ... }
+}
+```
+
+### Bonds (ERC-20)
+
+Bonds are fungible within the same issuance. The smart contract encodes coupon payments and maturity.
+
+**Key features:**
+- Automated coupon payments on schedule
+- Maturity date with redemption logic
+- Yield calculation helpers
+- Credit rating metadata
+
+```solidity
+contract BondToken is ERC20, Ownable {
+    uint256 public faceValue;
+    uint256 public couponRate;      // basis points
+    uint256 public maturityDate;
+    uint256 public couponFrequency; // seconds between payments
+
+    function payCoupon() external { ... }
+    function redeem() external { ... }
+}
+```
+
+### Futures & Options (ERC-1155)
+
+Derivatives are semi-fungible — contracts with the same strike and expiry are interchangeable, but different strikes are not. ERC-1155 handles this naturally.
+
+**Key features:**
+- Each token ID represents a unique (strike, expiry, type) combination
+- Expiry and settlement mechanics
+- Oracle integration for price feeds (Chainlink)
+- Margin and collateral management
+
+```solidity
+contract DerivativeToken is ERC1155, Ownable {
+    struct Contract {
+        uint256 strike;
+        uint256 expiry;
+        bool isCall;       // true = call, false = put
+        address underlying;
+    }
+
+    mapping(uint256 => Contract) public contracts;
+
+    function exercise(uint256 tokenId) external { ... }
+    function settle(uint256 tokenId) external { ... }
+}
+```
+
+---
+
+## Smart Contract Factory
+
+The factory pattern allows deploying new asset tokens with a single transaction:
+
+```solidity
+contract TokenFactory is Ownable {
+    event TokenCreated(address token, string assetType, string symbol);
+
+    function createEquity(
+        string memory name,
+        string memory symbol,
+        uint256 totalShares
+    ) external returns (address) { ... }
+
+    function createBond(
+        string memory name,
+        uint256 faceValue,
+        uint256 couponRate,
+        uint256 maturityDate
+    ) external returns (address) { ... }
+
+    function createDerivative(
+        address underlying,
+        uint256[] memory strikes,
+        uint256[] memory expiries
+    ) external returns (address) { ... }
+}
+```
+
+---
+
+## Technology Stack
+
+| Component | Technology | Why |
+|-----------|-----------|-----|
+| Smart Contracts | Solidity 0.8.x | Industry standard for Ethereum |
+| Framework | Hardhat | Testing, deployment, debugging |
+| Testing | Chai, Mocha | Comprehensive unit and integration tests |
+| Price Feeds | Chainlink | Decentralized oracle for settlement |
+| Frontend | React + ethers.js | Wallet connection and contract interaction |
+| Network | Ethereum Sepolia (testnet) | Free testing environment |
+
+---
+
+## Security Considerations
+
+Financial smart contracts require rigorous security:
+
+- **Reentrancy protection** — all external calls follow checks-effects-interactions
+- **Access control** — role-based permissions (admin, issuer, trader)
+- **Pausability** — emergency stop mechanism for all token contracts
+- **Upgradeability** — proxy pattern for bug fixes without redeployment
+- **Overflow protection** — Solidity 0.8.x built-in checks
+- **Oracle manipulation** — time-weighted average prices, multiple oracle sources
+
+---
+
+## What You'll Learn
+
+This project demonstrates:
+- How to model different financial instruments as smart contracts
+- The ERC-20 and ERC-1155 token standards and when to use each
+- Factory pattern for smart contract deployment
+- Oracle integration for real-world price data
+- Security patterns for financial smart contracts
+- Testing strategies for Solidity contracts
+
+---
+
+## Repository
+
+*Coming soon — the GitHub repository with full source code, deployment scripts, and test suite.*

--- a/_posts/2026-02-28-project-financial-engineering.md
+++ b/_posts/2026-02-28-project-financial-engineering.md
@@ -1,0 +1,161 @@
+---
+layout: single
+title: "Project: Financial Engineering & Risk Management System"
+date: 2026-02-28 10:00:00 +0800
+permalink: /projects/financial-engineering/
+categories:
+  - finance
+  - projects
+tags:
+  - trading
+  - risk-management
+  - clickhouse
+  - kafka
+  - java
+  - order-book
+  - real-time
+---
+
+Building a complete simulation trading and risk management system from scratch — the kind that powers real trading desks.
+
+This project demonstrates the full lifecycle: from order entry and trade matching to real-time risk calculation and dashboard delivery. It's designed to mirror the systems I've worked on at Standard Chartered Bank, simplified for demonstration but architecturally faithful.
+
+---
+
+## Overview
+
+The system has two main subsystems:
+
+1. **Trading System** — an order book engine that accepts orders, matches trades, and stores executions in ClickHouse
+2. **Risk System** — a real-time risk engine that computes PnL, Greeks, and other risk metrics, pushing updates to dashboards via an event queue
+
+Both systems support multiple asset classes: FX, bonds, equities, options, and derivatives.
+
+---
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────┐     ┌────────────┐
+│  Order Entry │────▶│  Order Book  │────▶│   Trade    │
+│   (Client)   │     │   Matching   │     │  Storage   │
+└─────────────┘     └──────────────┘     │ (ClickHouse)│
+                                          └─────┬──────┘
+                                                │
+                                          ┌─────▼──────┐
+                                          │   Event    │
+                                          │   Queue    │
+                                          └─────┬──────┘
+                                                │
+                    ┌───────────────────────────┼───────────────────────┐
+                    │                           │                       │
+              ┌─────▼──────┐            ┌──────▼──────┐         ┌─────▼──────┐
+              │   Risk     │            │    Risk     │         │  Dashboard │
+              │  Engine    │────────────▶│   Storage   │────────▶│  (React)   │
+              │ (PnL/Greeks)│            │ (ClickHouse)│         └────────────┘
+              └────────────┘            └─────────────┘
+```
+
+### Trading System
+
+**Order Book Engine**
+- Limit order book with price-time priority matching
+- Supports market, limit, and stop orders
+- Multi-asset: each instrument maintains its own order book
+
+**Trade Matching**
+- Continuous matching for equities and FX
+- Auction matching for derivatives
+- Partial fills and order amendments
+
+**Trade Storage**
+- ClickHouse as the columnar store for high-throughput trade ingestion
+- Designed for time-series queries: trade history, blotter views, aggregation by desk/portfolio
+
+### Risk System
+
+**Risk Engine**
+- Real-time computation triggered by trade events
+- Calculates per-trade and per-portfolio risk metrics
+- Supports different calculation profiles per trading desk
+
+**Risk Metrics**
+- **PnL** — Mark-to-market, realized vs unrealized
+- **DV01** — Dollar value of a basis point (interest rate sensitivity)
+- **Greeks** — Delta, gamma, theta, vega, rho for options
+- **VaR** — Value at Risk for portfolio-level risk monitoring
+
+**Limits Framework**
+- Per-desk risk limits (e.g., max notional, max DV01)
+- Per-portfolio limits
+- Breach alerting and pre-trade limit checks
+
+**Event Pipeline**
+- Trade booked → event published to queue
+- Risk engine consumes event, calculates risk
+- Risk numbers stored in ClickHouse
+- Dashboard receives notification to refresh
+
+---
+
+## Multi-Asset Coverage
+
+| Asset Class | Instruments | Key Risk Metrics |
+|-------------|-------------|-----------------|
+| **FX** | Spot, forwards, swaps | PnL, delta, DV01 |
+| **Bonds** | Government, corporate | PnL, DV01, duration, convexity |
+| **Equities** | Stocks, ETFs | PnL, delta, beta |
+| **Options** | Vanilla calls/puts | PnL, delta, gamma, theta, vega |
+| **Derivatives** | Futures, swaps | PnL, DV01, Greeks |
+
+Each trading desk sees only the risk metrics relevant to their book. An FX desk sees DV01 and spot delta. An options desk sees the full Greeks panel. The dashboard is configurable per desk.
+
+---
+
+## Technology Stack
+
+| Component | Technology | Why |
+|-----------|-----------|-----|
+| Core Engine | Java | Low-latency, strong concurrency |
+| Message Queue | Kafka | High-throughput event streaming |
+| Time-Series DB | ClickHouse | Columnar storage, fast aggregation |
+| Caching | Hazelcast | In-memory grid for hot risk data |
+| Dashboard | React | Real-time UI with WebSocket updates |
+
+---
+
+## Trading Desk Dashboards
+
+Different desks have different views:
+
+**FX Desk**
+- Live FX rates and spot positions
+- DV01 exposure by currency pair
+- PnL by book, intraday and cumulative
+
+**Rates Desk**
+- Bond portfolio duration and convexity
+- DV01 ladder by tenor bucket
+- Yield curve shifts and PnL attribution
+
+**Options Desk**
+- Full Greeks dashboard: delta, gamma, theta, vega
+- Volatility surface and skew
+- PnL decomposition by Greek
+
+---
+
+## What You'll Learn
+
+This project demonstrates:
+- How order books work and how trades are matched
+- Real-time risk calculation patterns used in investment banks
+- ClickHouse schema design for financial time-series data
+- Event-driven architecture for low-latency risk systems
+- How trading desks consume risk data differently
+
+---
+
+## Repository
+
+*Coming soon — the GitHub repository with full source code, setup instructions, and sample data.*

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -482,6 +482,27 @@ $dk-code:         #0d0d0d;
     h3 { color: $dk-heading; }
   }
 
+  // Projects Page
+  .projects-page__title { color: $dk-heading; }
+  .projects-page__description { color: $dk-muted; }
+
+  .project-card {
+    background: $dk-surface;
+    border-color: $dk-border;
+    color: $dk-text;
+    &:hover {
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+      color: $dk-text;
+    }
+  }
+  .project-card__title { color: $dk-heading; }
+  .project-card__excerpt { color: $dk-muted; }
+  .project-card__tag {
+    background: $dk-surface-alt;
+    border-color: $dk-border;
+    color: $dk-link;
+  }
+
   // Timeline nav blocks in personal posts
   div[style*="background:#f8f9fa"] {
     background: $dk-surface !important;
@@ -497,4 +518,120 @@ $dk-code:         #0d0d0d;
   max-width: 900px;
   margin: 2rem auto;
   padding: 1.5rem 1rem;
+}
+
+/* ── Projects Page ─────────────────────────────────── */
+.projects-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+.projects-page__header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+.projects-page__title {
+  font-family: $serif;
+  font-size: 2em;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+}
+.projects-page__description {
+  font-family: $serif;
+  font-size: 1.05em;
+  color: #7a8288;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ── Projects Grid ─────────────────────────────────── */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+/* ── Project Card ──────────────────────────────────── */
+.project-card {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e3edf4;
+  border-radius: 8px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+    text-decoration: none;
+    color: inherit;
+  }
+}
+.project-card__image {
+  width: 100%;
+  aspect-ratio: 5 / 3;
+  overflow: hidden;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+.project-card__body {
+  padding: 1rem 1.2rem 1.2rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.project-card__title {
+  font-family: $serif;
+  font-size: 1.05em;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 0.5rem 0;
+  color: #333;
+}
+.project-card__excerpt {
+  font-family: $serif;
+  font-size: 0.85em;
+  line-height: 1.5;
+  color: #7a8288;
+  margin: 0 0 0.8rem 0;
+  flex: 1;
+}
+.project-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.project-card__tag {
+  font-family: $sans-serif;
+  font-size: 0.7em;
+  padding: 2px 8px;
+  background: #eaf4fb;
+  border: 1px solid #add8e6;
+  border-radius: 12px;
+  color: #1f618d;
+  white-space: nowrap;
+}
+
+/* ── Projects Grid — Responsive ────────────────────── */
+@media (max-width: 1024px) {
+  .projects-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+  }
+}
+@media (max-width: 640px) {
+  .projects-page { padding: 1rem 0.75rem; }
+  .projects-page__title { font-size: 1.5em; }
+  .projects-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .project-card__image { aspect-ratio: 16 / 9; }
 }

--- a/assets/images/project-ai-agents.svg
+++ b/assets/images/project-ai-agents.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6c3483"/>
+      <stop offset="100%" style="stop-color:#8e44ad"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="240" fill="url(#bg)"/>
+  <!-- Agent nodes -->
+  <g opacity="0.9">
+    <!-- Central orchestrator -->
+    <circle cx="200" cy="120" r="32" fill="none" stroke="#fff" stroke-width="2.5"/>
+    <text x="200" y="126" text-anchor="middle" fill="#fff" font-size="14" font-family="sans-serif" font-weight="600">A2A</text>
+    <!-- Agent 1 - top left -->
+    <circle cx="100" cy="60" r="24" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="100" y="56" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Text</text>
+    <text x="100" y="68" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">2SQL</text>
+    <!-- Agent 2 - top right -->
+    <circle cx="300" cy="60" r="24" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="300" y="56" text-anchor="middle" fill="#fff" font-size="8" font-family="sans-serif">Text2</text>
+    <text x="300" y="68" text-anchor="middle" fill="#fff" font-size="8" font-family="sans-serif">Dashboard</text>
+    <!-- Agent 3 - bottom left -->
+    <circle cx="100" cy="180" r="24" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="100" y="176" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Chat</text>
+    <text x="100" y="188" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Agent</text>
+    <!-- Agent 4 - bottom right -->
+    <circle cx="300" cy="180" r="24" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="300" y="176" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Risk</text>
+    <text x="300" y="188" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Agent</text>
+    <!-- Connection lines -->
+    <line x1="130" y1="75" x2="170" y2="105" stroke="#fff" stroke-width="1.2" opacity="0.6"/>
+    <line x1="270" y1="75" x2="230" y2="105" stroke="#fff" stroke-width="1.2" opacity="0.6"/>
+    <line x1="130" y1="165" x2="170" y2="135" stroke="#fff" stroke-width="1.2" opacity="0.6"/>
+    <line x1="270" y1="165" x2="230" y2="135" stroke="#fff" stroke-width="1.2" opacity="0.6"/>
+    <!-- Arrows on lines -->
+    <circle cx="150" cy="90" r="2" fill="#fff" opacity="0.8"/>
+    <circle cx="250" cy="90" r="2" fill="#fff" opacity="0.8"/>
+    <circle cx="150" cy="150" r="2" fill="#fff" opacity="0.8"/>
+    <circle cx="250" cy="150" r="2" fill="#fff" opacity="0.8"/>
+  </g>
+</svg>

--- a/assets/images/project-blockchain.svg
+++ b/assets/images/project-blockchain.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e8449"/>
+      <stop offset="100%" style="stop-color:#27ae60"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="240" fill="url(#bg)"/>
+  <!-- Blockchain blocks -->
+  <g opacity="0.9">
+    <!-- Block 1 -->
+    <rect x="30" y="85" width="80" height="70" rx="6" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="70" y="110" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Stock</text>
+    <text x="70" y="124" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Token</text>
+    <text x="70" y="145" text-anchor="middle" fill="#fff" font-size="7" font-family="sans-serif" opacity="0.7">ERC-20</text>
+    <!-- Chain link 1 -->
+    <line x1="110" y1="120" x2="140" y2="120" stroke="#fff" stroke-width="2" opacity="0.6"/>
+    <circle cx="125" cy="120" r="3" fill="#fff" opacity="0.5"/>
+    <!-- Block 2 -->
+    <rect x="140" y="85" width="80" height="70" rx="6" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="180" y="110" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Bond</text>
+    <text x="180" y="124" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Token</text>
+    <text x="180" y="145" text-anchor="middle" fill="#fff" font-size="7" font-family="sans-serif" opacity="0.7">ERC-20</text>
+    <!-- Chain link 2 -->
+    <line x1="220" y1="120" x2="250" y2="120" stroke="#fff" stroke-width="2" opacity="0.6"/>
+    <circle cx="235" cy="120" r="3" fill="#fff" opacity="0.5"/>
+    <!-- Block 3 -->
+    <rect x="250" y="85" width="80" height="70" rx="6" fill="rgba(255,255,255,0.15)" stroke="#fff" stroke-width="1.5"/>
+    <text x="290" y="110" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Options</text>
+    <text x="290" y="124" text-anchor="middle" fill="#fff" font-size="9" font-family="sans-serif">Token</text>
+    <text x="290" y="145" text-anchor="middle" fill="#fff" font-size="7" font-family="sans-serif" opacity="0.7">ERC-1155</text>
+  </g>
+  <!-- Ethereum diamond -->
+  <g transform="translate(355,30)" opacity="0.4">
+    <polygon points="0,15 10,0 20,15 10,20" fill="#fff"/>
+    <polygon points="0,15 10,20 20,15 10,30" fill="#fff" opacity="0.7"/>
+  </g>
+</svg>

--- a/assets/images/project-finance.svg
+++ b/assets/images/project-finance.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a5276"/>
+      <stop offset="100%" style="stop-color:#2980b9"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="240" fill="url(#bg)"/>
+  <!-- Candlestick chart -->
+  <g transform="translate(80,40)" opacity="0.9">
+    <!-- Candle 1 - green -->
+    <line x1="30" y1="30" x2="30" y2="140" stroke="#2ecc71" stroke-width="2"/>
+    <rect x="20" y="60" width="20" height="50" fill="#2ecc71" rx="2"/>
+    <!-- Candle 2 - red -->
+    <line x1="70" y1="20" x2="70" y2="150" stroke="#e74c3c" stroke-width="2"/>
+    <rect x="60" y="40" width="20" height="70" fill="#e74c3c" rx="2"/>
+    <!-- Candle 3 - green -->
+    <line x1="110" y1="10" x2="110" y2="130" stroke="#2ecc71" stroke-width="2"/>
+    <rect x="100" y="30" width="20" height="60" fill="#2ecc71" rx="2"/>
+    <!-- Candle 4 - red -->
+    <line x1="150" y1="25" x2="150" y2="145" stroke="#e74c3c" stroke-width="2"/>
+    <rect x="140" y="50" width="20" height="55" fill="#e74c3c" rx="2"/>
+    <!-- Candle 5 - green -->
+    <line x1="190" y1="5" x2="190" y2="120" stroke="#2ecc71" stroke-width="2"/>
+    <rect x="180" y="20" width="20" height="65" fill="#2ecc71" rx="2"/>
+  </g>
+  <!-- Subtle grid lines -->
+  <g opacity="0.15" stroke="#fff" stroke-width="0.5">
+    <line x1="60" y1="60" x2="340" y2="60"/>
+    <line x1="60" y1="100" x2="340" y2="100"/>
+    <line x1="60" y1="140" x2="340" y2="140"/>
+    <line x1="60" y1="180" x2="340" y2="180"/>
+  </g>
+</svg>


### PR DESCRIPTION
Add a Projects menu item before GitHub in the navigation, linking to a
new /projects/ page that displays 3 project cards in a responsive grid.
Each card has an SVG thumbnail, title, excerpt, and tech tags, linking
to a detailed blog post.

Projects:
- Financial Engineering & Risk Management (trading, ClickHouse, risk)
- AI & Agents Workflow (text2sql, A2A protocol, dashboards)
- Blockchain & Smart Contracts (Solidity, tokenization, Ethereum)

Includes custom projects layout, card CSS with dark theme support, and
responsive breakpoints matching existing design patterns.

https://claude.ai/code/session_01BgM1XAN3t55M5TjM4Lrdmc