### PR TITLE
Remove Bits & Beyond from top bar and fix greedy-nav responsiveness

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,11 +9,6 @@
         <a class="site-author-link" href="{{ '/about/' | relative_url }}">Diep Dao</a>
       </div>
 
-      <!-- MIDDLE: Bits & Beyond → Home (absolutely centred) -->
-      <div class="masthead__center">
-        <a class="site-brand" href="{{ '/' | relative_url }}">Bits &amp; Beyond</a>
-      </div>
-
       <!-- RIGHT: Nav items (collapse on small screens) + theme switcher -->
       <div class="masthead__right">
         <nav id="site-nav" class="greedy-nav">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -19,10 +19,9 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
 }
 
 /* ── Custom Masthead Layout ──────────────────────────── */
-/* 3-column grid: equal 1fr sides keep center perfectly centred */
 .masthead__wrap {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto 1fr;
   align-items: center;
   width: 100%;
   padding: 0.4rem 0;
@@ -33,12 +32,6 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   display: flex;
   align-items: center;
   justify-self: start;
-}
-
-/* MIDDLE */
-.masthead__center {
-  white-space: nowrap;
-  text-align: center;
 }
 
 /* RIGHT — fills its 1fr column so greedy-nav can measure width */
@@ -58,21 +51,6 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   text-decoration: none;
   color: #494e52;
   &:hover { color: #000; }
-}
-
-.site-brand {
-  font-family: $sans-serif;
-  font-size: 1.05em;
-  font-weight: 400;
-  color: #7a8288;
-  white-space: nowrap;
-  text-decoration: none;
-  &:hover { color: #494e52; }
-}
-
-@media (max-width: 480px) {
-  .masthead__wrap { grid-template-columns: auto 1fr; }
-  .masthead__center { display: none; }
 }
 
 /* ── Avatar ─────────────────────────────────────────── */
@@ -318,7 +296,6 @@ $dk-code:         #0d0d0d;
       color: $dk-link !important;
       &:hover { color: $dk-link-hover !important; }
     }
-    .site-brand      { color: $dk-text; text-decoration: none; &:hover { color: $dk-heading; } }
     .site-author-link { color: $dk-heading; &:hover { color: $dk-link-hover; } }
     .greedy-nav {
       background-color: $dk-masthead;
@@ -470,7 +447,6 @@ $dk-code:         #0d0d0d;
     background: rgba(255,255,255,0.08);
     border-color: rgba(255,255,255,0.15);
   }
-  .masthead__right .site-brand { color: $dk-text; }
   .theme-btn {
     color: rgba(255,255,255,0.6);
     &:hover { background: rgba(255,255,255,0.15); color: #fff; }

--- a/assets/js/theme-switch.js
+++ b/assets/js/theme-switch.js
@@ -85,6 +85,13 @@
     createSwitcher();
   }
 
+  // Force greedy-nav to recalculate after full layout is painted.
+  // The Minimal Mistakes greedy-nav JS measures widths on DOMContentLoaded
+  // but a CSS grid layout may not be settled yet at that point.
+  window.addEventListener('load', function () {
+    window.dispatchEvent(new Event('resize'));
+  });
+
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
     if (!localStorage.getItem(STORAGE_KEY)) {
       var t = getSystemTheme();


### PR DESCRIPTION
- Remove the centre masthead div containing the "Bits & Beyond" brand link
- Simplify masthead grid from 3-column (1fr auto 1fr) to 2-column (auto 1fr)
- Drop now-unused .masthead__center, .site-brand CSS and dark-theme overrides
- Dispatch a window resize event on window.load so the Minimal Mistakes
  greedy-nav JS recalculates menu widths after the CSS grid is fully settled,
  fixing items not auto-collapsing / expanding on screen-size changes

https://claude.ai/code/session_01KLxL231f6HAxXukKNUowEh