### PR TITLE
fix: ensure Giscus comments widget theme syncs reliably on load

### DIFF
--- a/assets/js/theme-switch.js
+++ b/assets/js/theme-switch.js
@@ -25,7 +25,14 @@
       _giscusObserver.disconnect();
     }
     _giscusObserver = new MutationObserver(function () {
-      if (sendGiscusTheme(theme)) {
+      var giscusFrame = document.querySelector('iframe.giscus-frame');
+      if (giscusFrame) {
+        // Giscus iframe is injected, but might not be fully loaded to accept messages.
+        // Try sending now, but also add a load listener.
+        sendGiscusTheme(theme);
+        giscusFrame.addEventListener('load', function() {
+          sendGiscusTheme(getCurrentTheme());
+        });
         _giscusObserver.disconnect();
         _giscusObserver = null;
       }
@@ -40,7 +47,10 @@
       document.documentElement.removeAttribute('data-theme');
     }
     // Sync Giscus comment widget theme; watch for it if not yet in DOM
-    if (!sendGiscusTheme(theme)) {
+    var giscusFrame = document.querySelector('iframe.giscus-frame');
+    if (giscusFrame) {
+      sendGiscusTheme(theme);
+    } else {
       watchForGiscus(theme);
     }
   }


### PR DESCRIPTION
Resolved a race condition where the Giscus iframe was injected into the DOM but could not yet accept `postMessage` requests from the theme switcher because its internal application state hadn't initialized. Added a standard `'load'` event listener to retry sending the initial theme to the Giscus iframe, ensuring the comments section respects user theme preferences automatically.