### PR TITLE
Fix theme toggle button outline and add favicon to masthead

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -6,7 +6,10 @@
 
       <!-- LEFT: Diep Dao → About Me -->
       <div class="masthead__left">
-        <a class="site-author-link" href="{{ '/about/' | relative_url }}">Diep Dao</a>
+        <a class="site-author-link" href="{{ '/about/' | relative_url }}">
+          <img src="{{ '/assets/images/favicon.svg' | relative_url }}" alt="Logo" class="site-logo-icon">
+          Diep Dao
+        </a>
         <div id="theme-switcher-slot"></div>
       </div>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -50,7 +50,17 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   white-space: nowrap;
   text-decoration: none;
   color: #494e52;
+  display: flex;
+  align-items: center;
   &:hover { color: #000; }
+}
+
+.site-logo-icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 /* ── Avatar ─────────────────────────────────────────── */
@@ -250,7 +260,11 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   align-items: center;
   justify-content: center;
   transition: color 0.15s;
+  outline: none;
+  box-shadow: none;
   &:hover { color: #000; }
+  &:focus { outline: none; box-shadow: none; }
+  &:active { outline: none; box-shadow: none; }
 }
 
 /* ── Dark Theme ──────────────────────────────────────── */


### PR DESCRIPTION
This pull request addresses the two UI styling requests:
1. Fixes the theme switch button by removing the square outline/box-shadow that appeared when it was clicked or focused.
2. Adds the site's favicon before the author's name ("Diep Dao") in the masthead navigation bar. Flexbox was used to correctly align the image and text vertically.

---
*PR created automatically by Jules for task [18405151780456837897](https://jules.google.com/task/18405151780456837897) started by @diepdaocs*