### PR TITLE
Remove company mention, replace specific tech names with generic terms

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -7,11 +7,11 @@ projects:
   - title: "Financial Engineering & Risk Management"
     url: /projects/financial-engineering/
     image: /assets/images/project-finance.svg
-    excerpt: "A simulation trading system with real-time risk calculation — order books, trade matching, PnL, Greeks, and multi-asset risk dashboards powered by ClickHouse."
+    excerpt: "A simulation trading system with real-time risk calculation — order books, trade matching, PnL, Greeks, and multi-asset risk dashboards."
     tags:
       - Java
-      - ClickHouse
-      - Kafka
+      - Time Series DB
+      - MessageQueue
       - Risk Engine
 
   - title: "AI & Agents Workflow"

--- a/_posts/2026-02-28-project-financial-engineering.md
+++ b/_posts/2026-02-28-project-financial-engineering.md
@@ -9,8 +9,8 @@ categories:
 tags:
   - trading
   - risk-management
-  - clickhouse
-  - kafka
+  - time-series-db
+  - message-queue
   - java
   - order-book
   - real-time
@@ -18,7 +18,7 @@ tags:
 
 Building a complete simulation trading and risk management system from scratch — the kind that powers real trading desks.
 
-This project demonstrates the full lifecycle: from order entry and trade matching to real-time risk calculation and dashboard delivery. It's designed to mirror the systems I've worked on at Standard Chartered Bank, simplified for demonstration but architecturally faithful.
+This project demonstrates the full lifecycle: from order entry and trade matching to real-time risk calculation and dashboard delivery. It's designed to mirror the systems used at real trading desks, simplified for demonstration but architecturally faithful.
 
 ---
 
@@ -26,7 +26,7 @@ This project demonstrates the full lifecycle: from order entry and trade matchin
 
 The system has two main subsystems:
 
-1. **Trading System** — an order book engine that accepts orders, matches trades, and stores executions in ClickHouse
+1. **Trading System** — an order book engine that accepts orders, matches trades, and stores executions in a Time Series Database
 2. **Risk System** — a real-time risk engine that computes PnL, Greeks, and other risk metrics, pushing updates to dashboards via an event queue
 
 Both systems support multiple asset classes: FX, bonds, equities, options, and derivatives.
@@ -50,7 +50,7 @@ Both systems support multiple asset classes: FX, bonds, equities, options, and d
 - Partial fills and order amendments
 
 **Trade Storage**
-- ClickHouse as the columnar store for high-throughput trade ingestion
+- Time Series Database as the columnar store for high-throughput trade ingestion
 - Designed for time-series queries: trade history, blotter views, aggregation by desk/portfolio
 
 ### Risk System
@@ -74,7 +74,7 @@ Both systems support multiple asset classes: FX, bonds, equities, options, and d
 **Event Pipeline**
 - Trade booked → event published to queue
 - Risk engine consumes event, calculates risk
-- Risk numbers stored in ClickHouse
+- Risk numbers stored in Time Series Database
 - Dashboard receives notification to refresh
 
 ---
@@ -98,9 +98,9 @@ Each trading desk sees only the risk metrics relevant to their book. An FX desk 
 | Component | Technology | Why |
 |-----------|-----------|-----|
 | Core Engine | Java | Low-latency, strong concurrency |
-| Message Queue | Kafka | High-throughput event streaming |
-| Time-Series DB | ClickHouse | Columnar storage, fast aggregation |
-| Caching | Hazelcast | In-memory grid for hot risk data |
+| Message Queue | MessageQueue | High-throughput event streaming |
+| Time-Series DB | Time Series Database | Columnar storage, fast aggregation |
+| Caching | CachingService | In-memory grid for hot risk data |
 | Dashboard | React | Real-time UI with WebSocket updates |
 
 ---
@@ -131,7 +131,7 @@ Different desks have different views:
 This project demonstrates:
 - How order books work and how trades are matched
 - Real-time risk calculation patterns used in investment banks
-- ClickHouse schema design for financial time-series data
+- Time Series Database schema design for financial data
 - Event-driven architecture for low-latency risk systems
 - How trading desks consume risk data differently
 

--- a/assets/images/arch-finance.svg
+++ b/assets/images/arch-finance.svg
@@ -44,9 +44,9 @@
   <line x1="570" y1="110" x2="618" y2="110" stroke="#e65100" stroke-width="2" marker-end="url(#arrowOrange)"/>
   <defs><marker id="arrowOrange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#e65100"/></marker></defs>
 
-  <!-- Trade Storage (ClickHouse) -->
+  <!-- Trade Storage (Time Series DB) -->
   <rect x="620" y="76" width="170" height="68" rx="8" fill="#fff3e0" stroke="#e65100" stroke-width="1.5" filter="url(#shadow1)"/>
-  <text x="705" y="100" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">ClickHouse</text>
+  <text x="705" y="100" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">Time Series DB</text>
   <text x="705" y="117" text-anchor="middle" font-size="10" fill="#bf360c">Trade Storage</text>
   <text x="705" y="133" text-anchor="middle" font-size="9" fill="#a1887f">Columnar / Time-Series</text>
 
@@ -56,7 +56,7 @@
 
   <!-- Event Queue box -->
   <rect x="610" y="190" width="190" height="50" rx="25" fill="#f3e5f5" stroke="#6a1b9a" stroke-width="1.5" filter="url(#shadow1)"/>
-  <text x="705" y="212" text-anchor="middle" font-size="12" font-weight="700" fill="#6a1b9a">Kafka Event Queue</text>
+  <text x="705" y="212" text-anchor="middle" font-size="12" font-weight="700" fill="#6a1b9a">Message Queue</text>
   <text x="705" y="228" text-anchor="middle" font-size="9" fill="#9c27b0">Trade Events &amp; Notifications</text>
 
   <!-- ===== RISK SYSTEM (bottom) ===== -->
@@ -75,9 +75,9 @@
   <!-- Arrow from risk engine to risk storage -->
   <line x1="410" y1="340" x2="478" y2="340" stroke="#e65100" stroke-width="2" marker-end="url(#arrowOrange)"/>
 
-  <!-- Risk Storage (ClickHouse) -->
+  <!-- Risk Storage (Time Series DB) -->
   <rect x="480" y="300" width="170" height="80" rx="8" fill="#fff3e0" stroke="#e65100" stroke-width="1.5" filter="url(#shadow1)"/>
-  <text x="565" y="325" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">ClickHouse</text>
+  <text x="565" y="325" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">Time Series DB</text>
   <text x="565" y="342" text-anchor="middle" font-size="10" fill="#bf360c">Risk Storage</text>
   <text x="565" y="358" text-anchor="middle" font-size="9" fill="#a1887f">Risk Numbers</text>
   <text x="565" y="372" text-anchor="middle" font-size="9" fill="#a1887f">Per Desk / Portfolio</text>


### PR DESCRIPTION
- Remove Standard Chartered Bank reference from project description
- Replace Kafka → MessageQueue, ClickHouse → Time Series Database, Hazelcast → CachingService
- Update SVG architecture diagram to reflect generic tech names
- Update projects.md tags and excerpt accordingly

https://claude.ai/code/session_019qfPVeUpruBtG5221tSMMU