### PR TITLE
Update dark mode code block styling colors

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -342,8 +342,8 @@ $dk-code:         #0d0d0d;
 
   // Code
   code {
-    background-color: $dk-code;
-    color: #7dd3f0;
+    background-color: $dk-surface-alt;
+    color: #93c5fd;
     border: 1px solid $dk-border;
   }
   pre {


### PR DESCRIPTION
## Summary
Updated the color scheme for code blocks in dark mode to use more consistent design tokens and improve visual appearance.

## Changes
- Changed code block background color from `$dk-code` (#0d0d0d) to `$dk-surface-alt` for better consistency with the overall dark mode palette
- Updated code text color from #7dd3f0 (cyan) to #93c5fd (lighter blue) for improved readability and visual hierarchy

## Details
These changes align the code block styling with the broader dark mode color system by using the established `$dk-surface-alt` token instead of a hardcoded color variable, while also refining the text color to a softer blue that better complements the updated background.

https://claude.ai/code/session_018q89Sy5AcGid7rF1XbyBNi