### PR TITLE
Fix CS series 404 links, improve diagram and series index layout

### DIFF
--- a/_posts/2026-02-27-welcome-to-computer-science.md
+++ b/_posts/2026-02-27-welcome-to-computer-science.md
@@ -29,7 +29,35 @@ Whether you're a student, a junior engineer, or a seasoned developer looking for
 
 ## Series Posts
 
-1. [Introduction to Computer Science: From Bits to Generative AI](/2026/03/16/introduction-to-computer-science/) — a map of the entire CS landscape, from hardware and algorithms to machine learning and generative AI
-2. [Bits & Bytes: How Computers Encode, Transmit, and Decode Everything](/2026/03/16/bits-and-bytes/) — how numbers, text, audio, images, and video are encoded; how data travels across the internet; how it's decoded and rendered
+<div class="projects-grid" style="margin-top: 1rem;">
+
+  <a href="/computer-science/2026/03/16/introduction-to-computer-science/" class="project-card">
+    <div class="project-card__body">
+      <h2 class="project-card__title">1. Introduction to Computer Science: From Bits to Generative AI</h2>
+      <p class="project-card__excerpt">A map of the entire CS landscape — from hardware, algorithms, and data structures to machine learning and generative AI.</p>
+      <div class="project-card__tags">
+        <span class="project-card__tag">introduction</span>
+        <span class="project-card__tag">algorithms</span>
+        <span class="project-card__tag">machine-learning</span>
+        <span class="project-card__tag">generative-ai</span>
+      </div>
+    </div>
+  </a>
+
+  <a href="/computer-science/2026/03/16/bits-and-bytes/" class="project-card">
+    <div class="project-card__body">
+      <h2 class="project-card__title">2. Bits & Bytes: How Computers Encode, Transmit, and Decode Everything</h2>
+      <p class="project-card__excerpt">How numbers, text, audio, images, and video are encoded as bits; how data travels across the internet; how it's decoded and rendered.</p>
+      <div class="project-card__tags">
+        <span class="project-card__tag">bits</span>
+        <span class="project-card__tag">bytes</span>
+        <span class="project-card__tag">encoding</span>
+        <span class="project-card__tag">networking</span>
+        <span class="project-card__tag">tcp-ip</span>
+      </div>
+    </div>
+  </a>
+
+</div>
 
 Stay tuned for more deep-dive posts.

--- a/_posts/2026-03-16-bits-and-bytes.md
+++ b/_posts/2026-03-16-bits-and-bytes.md
@@ -18,7 +18,7 @@ tags:
   - video
 ---
 
-This is the second deep-dive in the [Computer Science Series](/2026/02/27/welcome-to-computer-science/). The [first post](/2026/03/16/introduction-to-computer-science/) mapped the entire CS landscape — from hardware to generative AI. Now we zoom in on the very first layer: **bits and bytes**.
+This is the second deep-dive in the [Computer Science Series](/computer-science/2026/02/27/welcome-to-computer-science/). The [first post](/computer-science/2026/03/16/introduction-to-computer-science/) mapped the entire CS landscape — from hardware to generative AI. Now we zoom in on the very first layer: **bits and bytes**.
 
 Every YouTube video you stream, every emoji you send, every song you play — it all comes down to the same thing: billions of **ones and zeros** flying through cables and the air at the speed of light.
 
@@ -30,7 +30,9 @@ This post traces the full journey. Starting from what a bit physically is, all t
 
 Before diving in, here's the complete picture. Every piece of data follows this path:
 
-![Bits & Bytes End-to-End Data Flow](/assets/images/bits-bytes-end-to-end-flow.png)
+<div class="post-diagram">
+  <img src="/assets/images/bits-bytes-end-to-end-flow.png" alt="Bits & Bytes End-to-End Data Flow">
+</div>
 
 Keep this diagram in mind as we walk through each layer.
 
@@ -469,4 +471,4 @@ The next time you stream a video or send a message, you'll know exactly what's h
 
 In the next post in this series, we'll go deeper into **how CPUs actually execute instructions** — the fetch-decode-execute cycle, branch prediction, out-of-order execution, and why modern CPUs are so fast.
 
-Back to the series: [Welcome to the Computer Science Series](/2026/02/27/welcome-to-computer-science/)
+Back to the series: [Welcome to the Computer Science Series](/computer-science/2026/02/27/welcome-to-computer-science/)

--- a/_posts/2026-03-16-introduction-to-computer-science.md
+++ b/_posts/2026-03-16-introduction-to-computer-science.md
@@ -15,7 +15,7 @@ tags:
   - networking
 ---
 
-This is the first deep-dive post in the [Computer Science Series](/2026/02/27/welcome-to-computer-science/). Whether you're just starting out or looking to consolidate your mental model of the field, this post gives you a map of the entire landscape — from the smallest unit of data a computer understands, all the way up to systems that can write code and generate images.
+This is the first deep-dive post in the [Computer Science Series](/computer-science/2026/02/27/welcome-to-computer-science/). Whether you're just starting out or looking to consolidate your mental model of the field, this post gives you a map of the entire landscape — from the smallest unit of data a computer understands, all the way up to systems that can write code and generate images.
 
 The structure below is inspired by Stanford's [CS101: Introduction to Computing Principles](https://online.stanford.edu/courses/soe-ycscs101-computer-science-101) — one of the best overviews of the field for any level of experience.
 
@@ -244,11 +244,11 @@ Each layer builds on the one below it. You can enter the field at any point, but
 
 The next post goes deep on the very first layer — **Bits & Bytes**: how numbers, text, audio, images, and video are encoded as binary; how data travels across the internet through TCP/IP, TLS, and CDNs; and how it's decoded and rendered on the receiving end.
 
-**[Read next: Bits & Bytes — How Computers Encode, Transmit, and Decode Everything →](/2026/03/16/bits-and-bytes/)**
+**[Read next: Bits & Bytes — How Computers Encode, Transmit, and Decode Everything →](/computer-science/2026/03/16/bits-and-bytes/)**
 
 Future posts will continue down the map — hardware, operating systems, networking, databases, and more. If there's a topic you'd like me to prioritize, drop a comment below.
 
-Back to the series: [Welcome to the Computer Science Series](/2026/02/27/welcome-to-computer-science/)
+Back to the series: [Welcome to the Computer Science Series](/computer-science/2026/02/27/welcome-to-computer-science/)
 
 ---
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -493,6 +493,12 @@ $dk-code:         #0a0a0a;
     color: $dk-muted;
   }
 
+  // Post diagram images
+  .post-diagram {
+    background: $dk-surface;
+    border-color: $dk-border;
+  }
+
   // Timeline nav blocks in personal posts
   div[style*="background:#f8f9fa"] {
     background: $dk-surface !important;
@@ -607,6 +613,23 @@ $dk-code:         #0a0a0a;
   border-radius: 12px;
   color: #1f618d;
   white-space: nowrap;
+}
+
+/* ── Post Diagram Image ─────────────────────────────── */
+.post-diagram {
+  border: 1px solid #e3edf4;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  margin: 1.5rem 0;
+  img {
+    width: 100%;
+    height: auto;
+    display: block;
+    max-height: 640px;
+    object-fit: contain;
+    object-position: top center;
+  }
 }
 
 /* ── Projects Grid — Responsive ────────────────────── */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,6 +1,7 @@
 ---
 # Only the main SCSS file needs front matter
 ---
+@charset "UTF-8";
 
 /* Perplexity Discover-inspired font stack */
 $serif: "PP Editorial New", "Editorial New", Ivar, Charter, "Sitka Text", Georgia, serif;
@@ -18,7 +19,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   line-height: 1.6;
 }
 
-/* ── Custom Masthead Layout ──────────────────────────── */
+/* -- Custom Masthead Layout ---------------------------- */
 .masthead__wrap {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -34,7 +35,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   justify-self: start;
 }
 
-/* RIGHT — fills its 1fr column so greedy-nav can measure width */
+/* RIGHT -- fills its 1fr column so greedy-nav can measure width */
 .masthead__right {
   display: flex;
   align-items: center;
@@ -63,7 +64,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   vertical-align: middle;
 }
 
-/* ── Avatar ─────────────────────────────────────────── */
+/* -- Avatar ------------------------------------------- */
 .author__avatar {
   width: 150px !important;
   height: 150px !important;
@@ -73,7 +74,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   display: block !important;
   margin: 0 0 1em 0 !important;
 }
-/* The theme wraps img in an <a> — make it fill the container */
+/* The theme wraps img in an <a> -- make it fill the container */
 .author__avatar a {
   display: block !important;
   width: 100% !important;
@@ -92,7 +93,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   display: block !important;
 }
 
-/* ── Author social links — no box border ─────────────── */
+/* -- Author social links -- no box border --------------- */
 .author__urls-wrapper {
   border: none !important;
   box-shadow: none !important;
@@ -102,7 +103,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   box-shadow: none !important;
 }
 
-/* ── Three-column home layout ────────────────────────── */
+/* -- Three-column home layout -------------------------- */
 .home-grid {
   display: grid;
   grid-template-columns: 210px 1fr 190px;
@@ -154,7 +155,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   }
 }
 
-/* ── Word Map ────────────────────────────────────────── */
+/* -- Word Map ------------------------------------------ */
 .wordmap {
   background: #f8f9fa;
   border: 1px solid #e3edf4;
@@ -195,7 +196,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   &:hover { text-decoration: underline; color: #1a3a4a; }
 }
 
-/* ── Tag Cloud ───────────────────────────────────────── */
+/* -- Tag Cloud ----------------------------------------- */
 .tagcloud {
   background: #f8f9fa;
   border: 1px solid #e3edf4;
@@ -242,7 +243,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   line-height: 1.4;
 }
 
-/* ── Theme Switcher ──────────────────────────────────── */
+/* -- Theme Switcher ------------------------------------ */
 #theme-switcher-slot {
   display: inline-flex;
   align-items: center;
@@ -269,7 +270,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   &:active { outline: none; box-shadow: none; }
 }
 
-/* ── Dark Theme ──────────────────────────────────────── */
+/* -- Dark Theme ---------------------------------------- */
 $dk-bg:           #0f0f0f;
 $dk-surface:      #1a1a1a;
 $dk-surface-alt:  #222222;
@@ -509,14 +510,14 @@ $dk-code:         #0a0a0a;
   }
 }
 
-/* ── Home page comments section ────────────────────── */
+/* -- Home page comments section ---------------------- */
 .home-comments {
   max-width: 900px;
   margin: 2rem auto;
   padding: 1.5rem 1rem;
 }
 
-/* ── Projects Page ─────────────────────────────────── */
+/* -- Projects Page ----------------------------------- */
 .projects-page {
   max-width: 960px;
   margin: 0 auto;
@@ -541,14 +542,14 @@ $dk-code:         #0a0a0a;
   line-height: 1.6;
 }
 
-/* ── Projects Grid ─────────────────────────────────── */
+/* -- Projects Grid ----------------------------------- */
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
 }
 
-/* ── Project Card ──────────────────────────────────── */
+/* -- Project Card ------------------------------------ */
 .project-card {
   display: flex;
   flex-direction: column;
@@ -615,7 +616,7 @@ $dk-code:         #0a0a0a;
   white-space: nowrap;
 }
 
-/* ── Post Diagram Image ─────────────────────────────── */
+/* -- Post Diagram Image ------------------------------- */
 .post-diagram {
   border: 1px solid #e3edf4;
   border-radius: 8px;
@@ -632,7 +633,7 @@ $dk-code:         #0a0a0a;
   }
 }
 
-/* ── Projects Grid — Responsive ────────────────────── */
+/* -- Projects Grid -- Responsive ---------------------- */
 @media (max-width: 1024px) {
   .projects-grid {
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
- Add /computer-science/ category prefix to all inter-post links across the
  CS series so they resolve correctly on the live site
- Wrap the bits-and-bytes end-to-end flow diagram in a styled .post-diagram
  card (border, border-radius, object-fit: contain) that matches the site's
  project page aesthetic; add dark-mode support
- Replace the plain numbered list on the CS series index with project-card
  style cards (reusing .project-card / .projects-grid CSS) for a richer,
  visually consistent look matching the Projects page

https://claude.ai/code/session_01WyzgMHMzT6ANvVUhVJeNR9