### PR TITLE
Fix broken post links by adding permalink config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ author:
       icon: "fab fa-fw fa-github"
       url: "https://github.com/diepdaocs"
 url: "https://diepdao.me"
+permalink: /:categories/:year/:month/:day/:title/
 copyright_url: "/about/"
 baseurl: ""
 repository: "diepdaocs/blog"


### PR DESCRIPTION
Without an explicit permalink setting, Jekyll defaults to date-style
URLs (/:categories/:year/:month/:day/:title.html) which don't match the
trailing-slash links used throughout the two recent CS series posts.

Adding permalink: /:categories/:year/:month/:day/:title/ (the Minimal
Mistakes recommended setting) makes Jekyll generate directory-based
index.html files so all internal cross-post links resolve correctly.

https://claude.ai/code/session_01WvNtHU7PHaUugdCfJgajkA