### PR TITLE
CS series: fix post dates, livereload, and thumbnail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    bigdecimal (4.0.1)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -308,6 +309,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bigdecimal
   csv
   github-pages
   jekyll-feed

--- a/_posts/2026-02-27-welcome-to-computer-science.md
+++ b/_posts/2026-02-27-welcome-to-computer-science.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Welcome to the Computer Science Series"
-date: 2026-02-27 09:00:00 +0800
+date: 2026-01-01 09:00:00 +0800
+permalink: /computer-science/2026/02/27/welcome-to-computer-science/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-16-bits-and-bytes.md
+++ b/_posts/2026-03-16-bits-and-bytes.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Bits & Bytes: How Computers Encode, Transmit, and Decode Everything"
-date: 2026-03-16 10:00:00 +0800
+date: 2026-01-02 10:00:00 +0800
+permalink: /computer-science/2026/03/16/bits-and-bytes/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-16-introduction-to-computer-science.md
+++ b/_posts/2026-03-16-introduction-to-computer-science.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Introduction to Computer Science: From Bits to Generative AI"
-date: 2026-03-16 09:00:00 +0800
+date: 2026-01-03 09:00:00 +0800
+permalink: /computer-science/2026/03/16/introduction-to-computer-science/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-21-computer-architecture.md
+++ b/_posts/2026-03-21-computer-architecture.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Computer Architecture: Inside the CPU"
-date: 2026-03-21 10:00:00 +0800
+date: 2026-01-04 10:00:00 +0800
+permalink: /computer-science/2026/03/21/computer-architecture/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-22-operating-systems.md
+++ b/_posts/2026-03-22-operating-systems.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Operating Systems: The Software That Runs Everything Else"
-date: 2026-03-22 10:00:00 +0800
+date: 2026-01-05 10:00:00 +0800
+permalink: /computer-science/2026/03/22/operating-systems/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-23-algorithms.md
+++ b/_posts/2026-03-23-algorithms.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Algorithms: Thinking About Efficiency"
-date: 2026-03-23 10:00:00 +0800
+date: 2026-01-06 10:00:00 +0800
+permalink: /computer-science/2026/03/23/algorithms/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-24-data-structures.md
+++ b/_posts/2026-03-24-data-structures.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Data Structures: The Right Container for the Right Job"
-date: 2026-03-24 10:00:00 +0800
+date: 2026-01-07 10:00:00 +0800
+permalink: /computer-science/2026/03/24/data-structures/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-25-networks-and-security.md
+++ b/_posts/2026-03-25-networks-and-security.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Networks & Security: How the Internet Works and How to Protect It"
-date: 2026-03-25 10:00:00 +0800
+date: 2026-01-08 10:00:00 +0800
+permalink: /computer-science/2026/03/25/networks-and-security/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-26-databases.md
+++ b/_posts/2026-03-26-databases.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Databases: Storing and Querying Data at Scale"
-date: 2026-03-26 10:00:00 +0800
+date: 2026-01-09 10:00:00 +0800
+permalink: /computer-science/2026/03/26/databases/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-27-application-development.md
+++ b/_posts/2026-03-27-application-development.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Application Development: Building Software That Lasts"
-date: 2026-03-27 10:00:00 +0800
+date: 2026-01-10 10:00:00 +0800
+permalink: /computer-science/2026/03/27/application-development/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-28-distributed-systems.md
+++ b/_posts/2026-03-28-distributed-systems.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Distributed Systems: When One Machine Is Not Enough"
-date: 2026-03-28 10:00:00 +0800
+date: 2026-01-11 10:00:00 +0800
+permalink: /computer-science/2026/03/28/distributed-systems/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-29-machine-learning.md
+++ b/_posts/2026-03-29-machine-learning.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Machine Learning: Teaching Computers to Learn"
-date: 2026-03-29 10:00:00 +0800
+date: 2026-01-12 10:00:00 +0800
+permalink: /computer-science/2026/03/29/machine-learning/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-30-deep-learning.md
+++ b/_posts/2026-03-30-deep-learning.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Deep Learning: Neural Networks and the Transformer Revolution"
-date: 2026-03-30 10:00:00 +0800
+date: 2026-01-13 10:00:00 +0800
+permalink: /computer-science/2026/03/30/deep-learning/
 categories:
   - computer-science
 tags:

--- a/_posts/2026-03-31-large-language-models.md
+++ b/_posts/2026-03-31-large-language-models.md
@@ -1,7 +1,8 @@
 ---
 layout: single
 title: "Large Language Models: How AI Understands and Generates Language"
-date: 2026-03-31 10:00:00 +0800
+date: 2026-01-14 10:00:00 +0800
+permalink: /computer-science/2026/03/31/large-language-models/
 categories:
   - computer-science
 tags:

--- a/assets/images/arch-application-development.svg
+++ b/assets/images/arch-application-development.svg
@@ -67,7 +67,7 @@
 
   <!-- TESTING PYRAMID -->
   <text x="30" y="295" font-size="10" font-weight="600" fill="#7c3aed" letter-spacing="1.2">TESTING PYRAMID</text>
-  <rect x="30" y="302" width="390" height="178" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="30" y="302" width="390" height="188" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- E2E -->
   <polygon points="215,318 260,350 170,350" fill="#fecdd3" stroke="#b91c1c" stroke-width="1.2"/>
@@ -89,7 +89,7 @@
 
   <!-- CI/CD Pipeline -->
   <text x="440" y="238" font-size="10" font-weight="600" fill="#15803d" letter-spacing="1.2">CI/CD PIPELINE  — ship safely, automatically</text>
-  <rect x="440" y="246" width="390" height="234" rx="8" fill="#fff" stroke="#15803d" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="440" y="246" width="390" height="244" rx="8" fill="#fff" stroke="#15803d" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- Steps -->
   <rect x="452" y="258" width="367" height="28" rx="5" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.2"/>

--- a/assets/images/arch-computer-architecture.svg
+++ b/assets/images/arch-computer-architecture.svg
@@ -46,7 +46,7 @@
   <text x="638" y="148" text-anchor="middle" font-size="9" fill="#93c5fd">or memory</text>
 
   <!-- Branch predictor -->
-  <rect x="726" y="88" width="118" height="72" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="726" y="88" width="118" height="76" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
   <text x="785" y="112" text-anchor="middle" font-size="11" font-weight="600" fill="#7c3aed">Branch</text>
   <text x="785" y="127" text-anchor="middle" font-size="11" font-weight="600" fill="#7c3aed">Predictor</text>
   <text x="785" y="144" text-anchor="middle" font-size="9" fill="#8b5cf6">~95% accurate</text>

--- a/assets/images/arch-deep-learning.svg
+++ b/assets/images/arch-deep-learning.svg
@@ -15,7 +15,7 @@
 
   <!-- NEURAL NETWORK -->
   <text x="30" y="78" font-size="10" font-weight="600" fill="#7c3aed" letter-spacing="1.2">NEURAL NETWORK  — layers of neurons learning features</text>
-  <rect x="30" y="85" width="390" height="220" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="30" y="85" width="390" height="232" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- Input layer label -->
   <text x="67" y="104" text-anchor="middle" font-size="9" fill="#7c3aed" font-weight="600">Input</text>

--- a/assets/images/arch-distributed-systems.svg
+++ b/assets/images/arch-distributed-systems.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" font-family="Inter, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 580" font-family="Inter, system-ui, sans-serif">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#faf5ff"/>
@@ -9,13 +9,13 @@
     <marker id="aB" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#1d4ed8"/></marker>
     <marker id="aG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#15803d"/></marker>
   </defs>
-  <rect width="860" height="520" rx="14" fill="url(#bg)"/>
+  <rect width="860" height="580" rx="14" fill="url(#bg)"/>
   <text x="430" y="34" text-anchor="middle" font-size="17" font-weight="700" fill="#1e3a5f">Distributed Systems — When One Machine Is Not Enough</text>
   <text x="430" y="52" text-anchor="middle" font-size="10.5" fill="#64748b">CAP Theorem · Raft Consensus · Replication · Sharding · Caching</text>
 
   <!-- RAFT CONSENSUS -->
   <text x="30" y="78" font-size="10" font-weight="600" fill="#7c3aed" letter-spacing="1.2">RAFT CONSENSUS  — how nodes agree on a leader</text>
-  <rect x="30" y="85" width="390" height="195" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="30" y="85" width="390" height="260" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- Leader node -->
   <rect x="150" y="100" width="110" height="70" rx="10" fill="#7c3aed" stroke="#5b21b6" stroke-width="2" filter="url(#sh)"/>
@@ -84,79 +84,79 @@
   <text x="625" y="248" font-size="8.5" fill="#92400e" text-anchor="middle">CA (only single node)</text>
 
   <!-- REPLICATION + SHARDING -->
-  <text x="30" y="302" font-size="10" font-weight="600" fill="#1d4ed8" letter-spacing="1.2">REPLICATION  — copies for safety and scale</text>
-  <rect x="30" y="310" width="390" height="92" rx="8" fill="#fff" stroke="#1d4ed8" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="30" y="357" font-size="10" font-weight="600" fill="#1d4ed8" letter-spacing="1.2">REPLICATION  — copies for safety and scale</text>
+  <rect x="30" y="365" width="390" height="92" rx="8" fill="#fff" stroke="#1d4ed8" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- Primary -->
-  <rect x="48" y="324" width="90" height="60" rx="6" fill="#1d4ed8" stroke="#1e40af" stroke-width="1.5" filter="url(#sh)"/>
-  <text x="93" y="347" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Primary</text>
-  <text x="93" y="362" text-anchor="middle" font-size="9" fill="#bfdbfe">writes here</text>
-  <text x="93" y="375" text-anchor="middle" font-size="8.5" fill="#93c5fd">source of truth</text>
+  <rect x="48" y="379" width="90" height="60" rx="6" fill="#1d4ed8" stroke="#1e40af" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="93" y="402" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Primary</text>
+  <text x="93" y="417" text-anchor="middle" font-size="9" fill="#bfdbfe">writes here</text>
+  <text x="93" y="430" text-anchor="middle" font-size="8.5" fill="#93c5fd">source of truth</text>
 
-  <line x1="138" y1="354" x2="158" y2="354" stroke="#1d4ed8" stroke-width="1.5" marker-end="url(#aB)"/>
-  <text x="148" y="346" text-anchor="middle" font-size="7.5" fill="#64748b">async</text>
+  <line x1="138" y1="409" x2="158" y2="409" stroke="#1d4ed8" stroke-width="1.5" marker-end="url(#aB)"/>
+  <text x="148" y="401" text-anchor="middle" font-size="7.5" fill="#64748b">async</text>
 
   <!-- Replicas -->
-  <rect x="160" y="324" width="80" height="60" rx="6" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.2"/>
-  <text x="200" y="347" text-anchor="middle" font-size="10" font-weight="600" fill="#1d4ed8">Replica 1</text>
-  <text x="200" y="362" text-anchor="middle" font-size="8.5" fill="#3b82f6">reads only</text>
-  <text x="200" y="375" text-anchor="middle" font-size="8" fill="#93c5fd">slightly stale</text>
+  <rect x="160" y="379" width="80" height="60" rx="6" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.2"/>
+  <text x="200" y="402" text-anchor="middle" font-size="10" font-weight="600" fill="#1d4ed8">Replica 1</text>
+  <text x="200" y="417" text-anchor="middle" font-size="8.5" fill="#3b82f6">reads only</text>
+  <text x="200" y="430" text-anchor="middle" font-size="8" fill="#93c5fd">slightly stale</text>
 
-  <line x1="240" y1="354" x2="258" y2="354" stroke="#1d4ed8" stroke-width="1.5" marker-end="url(#aB)"/>
+  <line x1="240" y1="409" x2="258" y2="409" stroke="#1d4ed8" stroke-width="1.5" marker-end="url(#aB)"/>
 
-  <rect x="260" y="324" width="80" height="60" rx="6" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.2"/>
-  <text x="300" y="347" text-anchor="middle" font-size="10" font-weight="600" fill="#1d4ed8">Replica 2</text>
-  <text x="300" y="362" text-anchor="middle" font-size="8.5" fill="#3b82f6">reads only</text>
-  <text x="300" y="375" text-anchor="middle" font-size="8" fill="#93c5fd">slightly stale</text>
+  <rect x="260" y="379" width="80" height="60" rx="6" fill="#dbeafe" stroke="#1d4ed8" stroke-width="1.2"/>
+  <text x="300" y="402" text-anchor="middle" font-size="10" font-weight="600" fill="#1d4ed8">Replica 2</text>
+  <text x="300" y="417" text-anchor="middle" font-size="8.5" fill="#3b82f6">reads only</text>
+  <text x="300" y="430" text-anchor="middle" font-size="8" fill="#93c5fd">slightly stale</text>
 
-  <text x="360" y="343" font-size="9.5" fill="#1d4ed8">3× read</text>
-  <text x="360" y="356" font-size="9.5" fill="#1d4ed8">throughput</text>
-  <text x="360" y="373" font-size="8.5" fill="#64748b">failover on</text>
-  <text x="360" y="383" font-size="8.5" fill="#64748b">primary crash</text>
+  <text x="360" y="398" font-size="9.5" fill="#1d4ed8">3× read</text>
+  <text x="360" y="411" font-size="9.5" fill="#1d4ed8">throughput</text>
+  <text x="360" y="428" font-size="8.5" fill="#64748b">failover on</text>
+  <text x="360" y="438" font-size="8.5" fill="#64748b">primary crash</text>
 
-  <text x="440" y="302" font-size="10" font-weight="600" fill="#15803d" letter-spacing="1.2">SHARDING  — split data for write scale</text>
-  <rect x="440" y="310" width="390" height="92" rx="8" fill="#fff" stroke="#15803d" stroke-width="1.5" filter="url(#sh)"/>
+  <text x="440" y="357" font-size="10" font-weight="600" fill="#15803d" letter-spacing="1.2">SHARDING  — split data for write scale</text>
+  <rect x="440" y="365" width="390" height="92" rx="8" fill="#fff" stroke="#15803d" stroke-width="1.5" filter="url(#sh)"/>
 
   <!-- Shards -->
-  <rect x="452" y="324" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
-  <text x="502" y="343" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 1</text>
-  <text x="502" y="358" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 0</text>
-  <text x="502" y="371" text-anchor="middle" font-size="8" fill="#4ade80">users 0, 3, 6, 9…</text>
-  <text x="502" y="382" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
+  <rect x="452" y="379" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+  <text x="502" y="398" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 1</text>
+  <text x="502" y="413" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 0</text>
+  <text x="502" y="426" text-anchor="middle" font-size="8" fill="#4ade80">users 0, 3, 6, 9…</text>
+  <text x="502" y="437" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
 
-  <rect x="562" y="324" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
-  <text x="612" y="343" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 2</text>
-  <text x="612" y="358" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 1</text>
-  <text x="612" y="371" text-anchor="middle" font-size="8" fill="#4ade80">users 1, 4, 7, 10…</text>
-  <text x="612" y="382" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
+  <rect x="562" y="379" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+  <text x="612" y="398" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 2</text>
+  <text x="612" y="413" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 1</text>
+  <text x="612" y="426" text-anchor="middle" font-size="8" fill="#4ade80">users 1, 4, 7, 10…</text>
+  <text x="612" y="437" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
 
-  <rect x="672" y="324" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
-  <text x="722" y="343" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 3</text>
-  <text x="722" y="358" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 2</text>
-  <text x="722" y="371" text-anchor="middle" font-size="8" fill="#4ade80">users 2, 5, 8, 11…</text>
-  <text x="722" y="382" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
+  <rect x="672" y="379" width="100" height="64" rx="6" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+  <text x="722" y="398" text-anchor="middle" font-size="10" font-weight="700" fill="#14532d">Shard 3</text>
+  <text x="722" y="413" text-anchor="middle" font-size="8.5" fill="#166534">user_id % 3 = 2</text>
+  <text x="722" y="426" text-anchor="middle" font-size="8" fill="#4ade80">users 2, 5, 8, 11…</text>
+  <text x="722" y="437" text-anchor="middle" font-size="8" fill="#86efac">1/3 of all data</text>
 
-  <text x="785" y="342" font-size="9" fill="#15803d">Each shard</text>
-  <text x="785" y="355" font-size="9" fill="#15803d">handles 1/3</text>
-  <text x="785" y="368" font-size="9" fill="#64748b">of writes.</text>
-  <text x="785" y="381" font-size="9" fill="#b91c1c">No cross-shard</text>
-  <text x="785" y="392" font-size="9" fill="#b91c1c">JOINs!</text>
+  <text x="785" y="397" font-size="9" fill="#15803d">Each shard</text>
+  <text x="785" y="410" font-size="9" fill="#15803d">handles 1/3</text>
+  <text x="785" y="423" font-size="9" fill="#64748b">of writes.</text>
+  <text x="785" y="436" font-size="9" fill="#b91c1c">No cross-shard</text>
+  <text x="785" y="447" font-size="9" fill="#b91c1c">JOINs!</text>
 
   <!-- Consistency models -->
-  <rect x="30" y="414" width="800" height="72" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
-  <text x="430" y="433" text-anchor="middle" font-size="11" font-weight="700" fill="#1e3a5f">Consistency Models — how fresh is the data you read?</text>
-  <text x="130" y="450" text-anchor="middle" font-size="9.5" font-weight="600" fill="#1d4ed8">Strong</text>
-  <text x="130" y="464" text-anchor="middle" font-size="9" fill="#3b82f6">always latest write</text>
-  <text x="130" y="476" text-anchor="middle" font-size="8.5" fill="#64748b">slower, safer</text>
-  <text x="350" y="450" text-anchor="middle" font-size="9.5" font-weight="600" fill="#7c3aed">Causal</text>
-  <text x="350" y="464" text-anchor="middle" font-size="9" fill="#8b5cf6">reads follow writes</text>
-  <text x="350" y="476" text-anchor="middle" font-size="8.5" fill="#64748b">your own writes visible</text>
-  <text x="570" y="450" text-anchor="middle" font-size="9.5" font-weight="600" fill="#d97706">Eventual</text>
-  <text x="570" y="464" text-anchor="middle" font-size="9" fill="#b45309">will converge, eventually</text>
-  <text x="570" y="476" text-anchor="middle" font-size="8.5" fill="#64748b">faster, briefly stale</text>
-  <text x="760" y="450" text-anchor="middle" font-size="9.5" font-weight="600" fill="#15803d">Use case fit</text>
-  <text x="760" y="464" text-anchor="middle" font-size="8.5" fill="#64748b">banking → strong</text>
-  <text x="760" y="476" text-anchor="middle" font-size="8.5" fill="#64748b">likes/views → eventual</text>
+  <rect x="30" y="469" width="800" height="72" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="430" y="488" text-anchor="middle" font-size="11" font-weight="700" fill="#1e3a5f">Consistency Models — how fresh is the data you read?</text>
+  <text x="130" y="505" text-anchor="middle" font-size="9.5" font-weight="600" fill="#1d4ed8">Strong</text>
+  <text x="130" y="519" text-anchor="middle" font-size="9" fill="#3b82f6">always latest write</text>
+  <text x="130" y="531" text-anchor="middle" font-size="8.5" fill="#64748b">slower, safer</text>
+  <text x="350" y="505" text-anchor="middle" font-size="9.5" font-weight="600" fill="#7c3aed">Causal</text>
+  <text x="350" y="519" text-anchor="middle" font-size="9" fill="#8b5cf6">reads follow writes</text>
+  <text x="350" y="531" text-anchor="middle" font-size="8.5" fill="#64748b">your own writes visible</text>
+  <text x="570" y="505" text-anchor="middle" font-size="9.5" font-weight="600" fill="#d97706">Eventual</text>
+  <text x="570" y="519" text-anchor="middle" font-size="9" fill="#b45309">will converge, eventually</text>
+  <text x="570" y="531" text-anchor="middle" font-size="8.5" fill="#64748b">faster, briefly stale</text>
+  <text x="760" y="505" text-anchor="middle" font-size="9.5" font-weight="600" fill="#15803d">Use case fit</text>
+  <text x="760" y="519" text-anchor="middle" font-size="8.5" fill="#64748b">banking → strong</text>
+  <text x="760" y="531" text-anchor="middle" font-size="8.5" fill="#64748b">likes/views → eventual</text>
 
-  <text x="430" y="512" text-anchor="middle" font-size="8.5" fill="#94a3b8">diepdao.me  ·  CS Series Post 9  ·  Distributed Systems</text>
+  <text x="430" y="567" text-anchor="middle" font-size="8.5" fill="#94a3b8">diepdao.me  ·  CS Series Post 9  ·  Distributed Systems</text>
 </svg>

--- a/assets/images/arch-networks-security.svg
+++ b/assets/images/arch-networks-security.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" font-family="Inter, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 580" font-family="Inter, system-ui, sans-serif">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#f0fdf4"/>
@@ -9,7 +9,7 @@
     <marker id="aG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="#15803d"/></marker>
   </defs>
 
-  <rect width="860" height="520" rx="14" fill="url(#bg)"/>
+  <rect width="860" height="580" rx="14" fill="url(#bg)"/>
   <text x="430" y="34" text-anchor="middle" font-size="17" font-weight="700" fill="#1e3a5f">Networks &amp; Security — From URL to Encrypted Response</text>
   <text x="430" y="52" text-anchor="middle" font-size="10.5" fill="#64748b">DNS · TCP Handshake · TLS · HTTP · Cryptography · Common Attacks</text>
 
@@ -88,7 +88,7 @@
 
   <!-- CRYPTOGRAPHY + ATTACKS -->
   <text x="30" y="374" font-size="10" font-weight="600" fill="#7c3aed" letter-spacing="1.2">CRYPTOGRAPHY</text>
-  <rect x="30" y="382" width="390" height="100" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="30" y="382" width="390" height="140" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.5" filter="url(#sh)"/>
   <text x="50" y="402" font-size="10" font-weight="600" fill="#5b21b6">Symmetric (AES-256)</text>
   <text x="50" y="418" font-size="9.5" fill="#7c3aed">same key encrypts + decrypts  · fast</text>
   <text x="50" y="434" font-size="9" fill="#94a3b8">used for bulk data after TLS handshake</text>
@@ -96,20 +96,19 @@
   <text x="50" y="458" font-size="10" font-weight="600" fill="#5b21b6">Asymmetric (RSA / ECDSA)</text>
   <text x="50" y="474" font-size="9.5" fill="#7c3aed">public key encrypts · private key decrypts</text>
   <text x="50" y="488" font-size="9" fill="#94a3b8">used for TLS handshake · code signing · SSH</text>
-  <text x="50" y="500" font-size="9" fill="#7c3aed">embedding("king")−embedding("man")+embedding("woman")≈embedding("queen")</text>
-  <text x="220" y="500" text-anchor="middle" font-size="9" fill="#94a3b8">SHA-256 hash: one-way fingerprint · verify integrity</text>
+  <text x="50" y="504" font-size="9" fill="#94a3b8">SHA-256 hash: one-way fingerprint · verify integrity</text>
 
   <text x="440" y="374" font-size="10" font-weight="600" fill="#b91c1c" letter-spacing="1.2">COMMON ATTACKS + DEFENCES</text>
-  <rect x="440" y="382" width="390" height="100" rx="8" fill="#fff1f2" stroke="#b91c1c" stroke-width="1.5" filter="url(#sh)"/>
+  <rect x="440" y="382" width="390" height="140" rx="8" fill="#fff1f2" stroke="#b91c1c" stroke-width="1.5" filter="url(#sh)"/>
   <text x="460" y="402" font-size="10" font-weight="600" fill="#b91c1c">SQL Injection</text>
   <text x="460" y="418" font-size="9" fill="#7f1d1d">User input becomes SQL code → leak all data</text>
   <text x="460" y="430" font-size="9" fill="#16a34a">Fix: parameterized queries (cursor.execute(q, params))</text>
-  <line x1="460" y1="438" x2="818" y2="438" stroke="#fecdd3" stroke-width="1"/>
-  <text x="460" y="454" font-size="10" font-weight="600" fill="#b91c1c">XSS  (Cross-Site Scripting)</text>
-  <text x="460" y="470" font-size="9" fill="#7f1d1d">Attacker injects &lt;script&gt; that runs in victim's browser</text>
-  <text x="460" y="482" font-size="9" fill="#16a34a">Fix: escape all output  (&lt; → &amp;lt;, &gt; → &amp;gt;)</text>
-  <line x1="460" y1="490" x2="818" y2="490" stroke="#fecdd3" stroke-width="1"/>
-  <text x="460" y="506" font-size="9" fill="#7f1d1d">Phishing · MitM → Fix: HTTPS · check URLs · use 2FA</text>
+  <line x1="460" y1="440" x2="818" y2="440" stroke="#fecdd3" stroke-width="1"/>
+  <text x="460" y="456" font-size="10" font-weight="600" fill="#b91c1c">XSS  (Cross-Site Scripting)</text>
+  <text x="460" y="472" font-size="9" fill="#7f1d1d">Attacker injects &lt;script&gt; that runs in victim's browser</text>
+  <text x="460" y="484" font-size="9" fill="#16a34a">Fix: escape all output  (&lt; → &amp;lt;, &gt; → &amp;gt;)</text>
+  <line x1="460" y1="494" x2="818" y2="494" stroke="#fecdd3" stroke-width="1"/>
+  <text x="460" y="508" font-size="9" fill="#7f1d1d">Phishing · MitM → Fix: HTTPS · check URLs · use 2FA</text>
 
-  <text x="430" y="516" text-anchor="middle" font-size="8.5" fill="#94a3b8">diepdao.me  ·  CS Series Post 6  ·  Networks &amp; Security</text>
+  <text x="430" y="572" text-anchor="middle" font-size="8.5" fill="#94a3b8">diepdao.me  ·  CS Series Post 6  ·  Networks &amp; Security</text>
 </svg>


### PR DESCRIPTION
## Summary

This PR continues building out the Computer Science series blog with several fixes:

- **CS posts backdated to January 2026** — all 14 CS posts (Posts 0–12 + intro) now have dates Jan 1–14 2026, making them chronologically older than all project posts (Feb 28+). `permalink:` overrides preserve the original URLs so no cross-links break.
- **Removed personalized agents thumbnail label** — stripped the "OpenClaw · Personalized Agents" text from the bottom of the project card SVG.
- **Fixed Jekyll livereload on Ruby 3.1** — patched `jekyll-3.9.0/lib/jekyll/utils/platforms.rb` to use `File.read` instead of `Pathutil` and catch `StandardError`, fixing the watch/livereload crash on Linux.

## What's included (across all commits since main)

| Change | Detail |
|--------|--------|
| 11 new CS posts | Computer Architecture → LLMs (Posts 2–12) |
| 11 SVG diagrams | `arch-*.svg` for each post |
| Welcome post updated | All "coming soon" cards linked |
| Post dates | Backdated to Jan 2026; URLs unchanged |
| Thumbnail fix | Removed bottom label from personalized agents SVG |
| Jekyll fix | livereload now works with `--host 0.0.0.0 --livereload` |

## Test plan
- [ ] All CS post URLs return 200 locally
- [ ] CS posts appear before project posts in chronological feed
- [ ] Personalized agents card shows no bottom text
- [ ] `jekyll serve --livereload` starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)