### PR TITLE
Add desktop reading styles and set default post layout to single wide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,8 @@ defaults:
       path: ""
       type: "posts"
     values:
+      layout: single
+      classes: wide
       comments: true
 
 # Newsletter / mailing-list configuration (Mailchimp)

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -64,6 +64,25 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   vertical-align: middle;
 }
 
+/* -- Reading page desktop sizing ----------------------- */
+@media (min-width: 1024px) {
+  .layout--single .page {
+    max-width: min(1000px, calc(100% - 3rem));
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .layout--single .page__title {
+    font-size: clamp(2rem, 2.2vw, 2.6rem);
+    line-height: 1.2;
+  }
+
+  .layout--single .page__content {
+    font-size: 1.2rem;
+    line-height: 1.8;
+  }
+}
+
 /* -- Avatar ------------------------------------------- */
 .author__avatar {
   width: 150px !important;


### PR DESCRIPTION
### Motivation
- Ensure blog posts use the single-column reading layout and improve desktop typography and width for a better reading experience.

### Description
- Update `_config.yml` to set defaults for `type: "posts"` to `layout: single` and `classes: wide`, and add responsive desktop sizing rules in `assets/css/main.scss` that constrain `.layout--single .page` width and tune `.page__title` and `.page__content` font sizes and line heights.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b9dda47c83238945eb6a376fc3a8)