### PR TITLE
[codex] Balance home sidebar widths

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -150,7 +150,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
 /* -- Three-column home layout -------------------------- */
 .home-grid {
   display: grid;
-  grid-template-columns: minmax(170px, 210px) minmax(0, 1fr) minmax(170px, 190px);
+  grid-template-columns: minmax(220px, 240px) minmax(0, 1fr) minmax(220px, 240px);
   grid-template-areas: "left center right";
   gap: 2rem;
   align-items: start;
@@ -192,7 +192,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
 
 @media (max-width: 1024px) {
   .home-grid {
-    grid-template-columns: minmax(0, 1fr) 180px;
+    grid-template-columns: minmax(0, 1fr) 220px;
     grid-template-areas: "center right" "left right";
     width: calc(100% - 1.5rem);
     max-width: 900px;
@@ -265,6 +265,8 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   position: sticky;
   top: 2rem;
   margin-top: 1.5rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 .tagcloud__title {
   font-family: $sans-serif;
@@ -733,6 +735,8 @@ $dk-code:         #0a0a0a;
   border-radius: 8px;
   padding: 1rem 1.1rem;
   margin-top: 1rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 .newsletter-widget__title {
   font-family: $sans-serif;


### PR DESCRIPTION
## Summary

- Makes the left and right home page columns use matching wider tracks.
- Lets the newsletter and tags boxes fill the right sidebar width consistently.
- Widens the tablet right rail to match the updated sidebar sizing.

## Why

After the desktop layout fix, the right sidebar still felt visually smaller than the Topics panel. This keeps Topics, Newsletter, and Tags balanced on desktop and tablet widths.

## Validation

- `git diff --check origin/main..HEAD` passed.

Note: local full Jekyll builds are still blocked by the existing Ruby/Jekyll/Liquid compatibility issue seen on the previous PR (`undefined method tainted? for nil:NilClass` in `/_layouts/single.html`).