### PR TITLE
[codex] Align home tags panel

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -433,7 +433,7 @@ html, body, p, li, h1, h2, h3, h4, h5, h6, .page__content {
   padding: 1rem 1.1rem;
   position: sticky;
   top: 2rem;
-  margin-top: 1.5rem;
+  margin-top: 0;
   width: 100%;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## What changed

- Removed the extra top margin from the home page Tags panel so it aligns with the Recent Posts column on tablet/desktop layouts.

## Why

After moving Newsletter below Topics, the Tags panel became the first item in the right sidebar. The old margin made it sit lower than Topics/Recent Posts.

## Validation

- Verified the tablet layout at `768px`: Tags and Recent Posts start at the same top position.
- Ran `bundle exec jekyll build` with the existing Ruby 3.2 compatibility preload for the repo's Jekyll 3.9/Liquid taint API issue.