### PR TITLE
Add Finance series: new posts and update welcome overview

### DIFF
--- a/_posts/2026-02-27-welcome-to-finance.md
+++ b/_posts/2026-02-27-welcome-to-finance.md
@@ -11,23 +11,24 @@ tags:
   - trading
 ---
 
-Finance and technology have been intertwined throughout my career. Working on a financial market terminal at Standard Chartered Bank — computing PnL, Greeks, and real-time risk for trading desks — gave me a front-row seat to how technology powers modern financial markets.
+Finance and technology have been intertwined throughout my career. Working on financial market terminals, corporate banking workflows, and real-time risk dashboards taught me that context matters as much as code.
 
 ## What This Series Is About
 
-This series sits at the intersection of finance and engineering:
+This series is a software-engineering map of finance:
 
-- **Financial Market Concepts** — how markets work, what traders actually look at, and the mechanics behind instruments like options and futures
-- **Quantitative Finance** — pricing models, risk metrics (PnL, Greeks, VaR), and the mathematics underneath
-- **FinTech Engineering** — building low-latency, high-reliability systems for financial applications
-- **Personal Finance** — investing principles, mental models for thinking about money, and lessons learned
+- how markets function
+- how financial institutions operate
+- how loans and facilities work in corporate banking
+- how risk numbers are computed and trusted
+- how trader-facing systems are built for reliability and speed
 
-## Why Finance
+## Series Roadmap
 
-Most software engineers don't need to understand finance deeply. But if you're building systems where money moves — whether that's a trading platform, a payments app, or a DeFi protocol — understanding the financial context makes you a dramatically better engineer.
-
-That's the angle I'll be writing from: a software engineer who had to learn finance on the job, and found it far more interesting than expected.
-
-## Articles in This Series
-
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [Introduction to Financial Markets: A Software Engineer’s Map](/finance/2026/03/17/introduction-to-financial-markets/)
+- [Market Microstructure: How Trades Actually Happen](/finance/2026/03/18/market-microstructure/)
+- [Financial Engineering for Builders: Pricing, Curves, and Risk](/finance/2026/03/19/financial-engineering-for-builders/)
+- [Banking and Financial Institutions: Operating Model for Engineers](/finance/2026/03/20/banking-and-financial-institutions/)
+- [Corporate Banking Systems: Loans, Facilities, and Controls](/finance/2026/03/21/corporate-banking-systems/)
+- [Risk Management and Trader Dashboards: From Trades to Decisions](/finance/2026/03/22/risk-management-and-trader-dashboards/)
+- [Project: Financial Engineering & Risk Management System](/projects/financial-engineering/)

--- a/_posts/2026-03-17-introduction-to-financial-markets.md
+++ b/_posts/2026-03-17-introduction-to-financial-markets.md
@@ -1,0 +1,165 @@
+---
+layout: single
+title: "Introduction to Financial Markets: A Software Engineer’s Map"
+date: 2026-03-17 09:00:00 +0800
+permalink: /finance/2026/03/17/introduction-to-financial-markets/
+categories:
+  - finance
+tags:
+  - financial-markets
+  - risk-management
+  - trading
+  - corporate-banking
+  - financial-engineering
+---
+
+If computer science gives you the language of systems, finance gives you the language of money, risk, and incentives. As a software engineer working across corporate banking, trading, portfolios, and risk dashboards, I found that understanding the domain changes how you design software.
+
+This post is a practical map of the core concepts every engineer in a bank should know.
+
+---
+
+## 1. Financial Markets in One View
+
+At a high level, financial markets connect three groups:
+
+- **Capital providers** (investors, funds, banks)
+- **Capital users** (companies, governments, institutions)
+- **Intermediaries** (exchanges, brokers, clearing houses, banks)
+
+The main market segments:
+
+- **Money markets** (short-term funding)
+- **Capital markets** (equity and debt for longer-term funding)
+- **FX markets** (currencies)
+- **Rates markets** (government bonds, swaps)
+- **Credit markets** (corporate bonds, CDS)
+- **Derivatives markets** (futures, options, structured products)
+
+As engineers, this structure matters because every subsystem we build (trade capture, risk, limits, settlement, reporting) maps to one or more market segments.
+
+---
+
+## 2. Financial Engineering: Pricing + Models + Data
+
+Financial engineering is where mathematics, statistics, and software meet.
+
+Core building blocks:
+
+- **Pricing models**: present value, discounting, yield curves, option pricing
+- **Market data models**: curves, surfaces, historical time series, volatility snapshots
+- **Risk models**: sensitivities (Greeks, DV01), stress scenarios, VaR
+
+In production systems, the challenge is not just model correctness. It is also:
+
+- deterministic reproducibility
+- latency budgets
+- explainability of risk numbers
+- traceability from market data snapshot to final report
+
+See the implementation blueprint in this project: **[Project: Financial Engineering & Risk Management System](/projects/financial-engineering/)**.
+
+---
+
+## 3. Banking & Institutions: Who Does What
+
+In most global banks, the institutional setup looks like this:
+
+- **Front Office**: sales + traders, revenue generation, pricing and execution
+- **Middle Office**: risk control, PnL explain, limit monitoring
+- **Back Office**: confirmations, settlement, reconciliation
+- **Treasury**: liquidity and funding
+- **Finance/Regulatory**: accounting and regulatory reports
+
+Different teams care about the same trade in different ways:
+
+- Trader: fill quality, market impact, position
+- Risk manager: exposure, concentration, stress loss
+- Operations: booking correctness and settlement status
+- Finance: valuation and ledger alignment
+
+Good internal platforms unify these views without duplicating logic.
+
+---
+
+## 4. Corporate Banking: Loans, Facilities, and Client Risk
+
+Corporate banking systems usually center around:
+
+- **Client onboarding** (KYC, legal entities, hierarchies)
+- **Credit facilities** (limits, drawdowns, utilization)
+- **Loan lifecycle** (origination → disbursement → repayment)
+- **Covenants and monitoring**
+- **Collateral and guarantees**
+
+From an engineering perspective, corporate banking is workflow-heavy and audit-heavy. Two design principles matter:
+
+1. **Event history is a first-class dataset** (who changed what, when, and why)
+2. **Reference data consistency** across loans, clients, facilities, and exposures
+
+When these are weak, downstream risk and finance numbers drift.
+
+---
+
+## 5. Risk Management: What Risk Numbers Actually Mean
+
+The most common risk numbers you will see on trading and portfolio dashboards:
+
+- **PnL**: realized and unrealized profit/loss
+- **DV01/PV01**: sensitivity to 1bp rate moves
+- **Delta/Gamma/Vega/Theta/Rho**: option sensitivities
+- **VaR**: distribution-based portfolio loss estimate
+- **Stress loss**: scenario-based losses under extreme moves
+
+For engineers, the key is lineage:
+
+`Trade + Market Data + Model Version + Netting Rules + Aggregation Hierarchy → Risk Number`
+
+If any component is ambiguous, trust in the number collapses.
+
+---
+
+## 6. Traders and the Risk Dashboard Contract
+
+A trader-facing risk dashboard is not just visualization. It is an operational contract:
+
+- **Timeliness**: updates must arrive within desk-specific SLAs
+- **Consistency**: totals must reconcile across drill-down levels
+- **Context**: each metric should be explainable and attributable
+- **Actionability**: users can identify the trades/drivers behind moves
+
+Typical views that matter most on desks:
+
+- PnL by book / trader / strategy
+- Greeks by maturity bucket
+- VaR and stress compared to limits
+- Top risk contributors and concentration hotspots
+
+---
+
+## 7. Practical Engineering Patterns for Bank Systems
+
+Patterns that repeatedly work well:
+
+- **Event-driven pipelines** for trade lifecycle and risk recalculation
+- **Idempotent consumers** for replay safety
+- **Immutable market-data snapshots** for reproducibility
+- **Explicit versioning** of models and valuation parameters
+- **As-of-time queries** for audit and investigations
+
+Patterns that usually create pain:
+
+- hidden in-place mutations of trade state
+- risk calculators tightly coupled to UI-specific formatting
+- ad-hoc joins across ungoverned reference data
+
+---
+
+## What’s Next in the Finance Series
+
+Start here:
+
+- **[Welcome to the Finance Series](/finance/2026/02/27/welcome-to-finance/)**
+- **[Project: Financial Engineering & Risk Management System](/projects/financial-engineering/)**
+
+Next deep dives will cover market microstructure, valuation pipelines, and production risk controls in more detail.

--- a/_posts/2026-03-18-market-microstructure.md
+++ b/_posts/2026-03-18-market-microstructure.md
@@ -1,0 +1,49 @@
+---
+layout: single
+title: "Market Microstructure: How Trades Actually Happen"
+date: 2026-03-18 09:00:00 +0800
+permalink: /finance/2026/03/18/market-microstructure/
+categories:
+  - finance
+tags:
+  - market-microstructure
+  - trading
+  - order-book
+  - execution
+---
+
+Market microstructure is the study of how buyers and sellers interact, how prices form, and how orders become trades. For engineers, this is where system behavior directly changes financial outcomes.
+
+## Core Concepts
+
+- **Order types**: market, limit, stop, iceberg.
+- **Order book**: bid/ask levels with price-time priority.
+- **Spread**: ask minus bid; a key transaction cost.
+- **Liquidity**: how much can be traded without moving price.
+- **Slippage**: difference between expected and executed price.
+
+## Why Engineers Should Care
+
+- Matching-engine latency changes fill quality.
+- Queue position affects execution probability.
+- Throttling and retries can create accidental duplicate orders.
+- Timestamp precision is critical for post-trade analysis.
+
+## Practical System Design Notes
+
+- Use immutable execution events.
+- Keep clock synchronization explicit (NTP/PTP strategy).
+- Separate market-data ingestion from order-routing paths.
+- Build replay tooling for execution incident investigation.
+
+## References
+
+- [BIS: Market Microstructure](https://www.bis.org/publ/work331.htm)
+- [SEC: Market Structure Overview](https://www.sec.gov/marketstructure)
+- [CFA Institute: Market Microstructure Basics](https://www.cfainstitute.org/insights)
+
+## Best Books to Read
+
+- *Trading and Exchanges* — Larry Harris
+- *Algorithmic Trading and DMA* — Barry Johnson
+- *Market Microstructure Theory* — Maureen O'Hara

--- a/_posts/2026-03-19-financial-engineering-for-builders.md
+++ b/_posts/2026-03-19-financial-engineering-for-builders.md
@@ -1,0 +1,48 @@
+---
+layout: single
+title: "Financial Engineering for Builders: Pricing, Curves, and Risk"
+date: 2026-03-19 09:00:00 +0800
+permalink: /finance/2026/03/19/financial-engineering-for-builders/
+categories:
+  - finance
+tags:
+  - financial-engineering
+  - pricing
+  - quantitative-finance
+  - risk
+---
+
+Financial engineering in production is the discipline of turning models into reliable, explainable, and testable systems.
+
+## Core Building Blocks
+
+- **Discounting** and present value
+- **Curves** (OIS, LIBOR fallback/term benchmarks, credit curves)
+- **Volatility surfaces** for options
+- **Sensitivities** (DV01, delta, gamma, vega)
+- **Scenario and stress engines**
+
+## Engineering Priorities
+
+- Deterministic valuation runs for reproducibility.
+- Version everything: models, market data, conventions.
+- Explainability: contribution analysis by trade and factor.
+- Fast incremental recalculation after trade events.
+
+## Common Failure Modes
+
+- Hidden convention mismatches (day count, calendars).
+- Mixing stale and live market snapshots.
+- Non-idempotent risk aggregation jobs.
+
+## References
+
+- [ISDA: Risk and Initial Margin](https://www.isda.org/category/risk/)
+- [Bank of England: Yield Curves and Discounting](https://www.bankofengland.co.uk/)
+- [CME Education: Options Greeks](https://www.cmegroup.com/education.html)
+
+## Best Books to Read
+
+- *Options, Futures, and Other Derivatives* — John C. Hull
+- *Paul Wilmott Introduces Quantitative Finance* — Paul Wilmott
+- *Interest Rate Markets* — Siddhartha Jha

--- a/_posts/2026-03-20-banking-and-financial-institutions.md
+++ b/_posts/2026-03-20-banking-and-financial-institutions.md
@@ -1,0 +1,47 @@
+---
+layout: single
+title: "Banking and Financial Institutions: Operating Model for Engineers"
+date: 2026-03-20 09:00:00 +0800
+permalink: /finance/2026/03/20/banking-and-financial-institutions/
+categories:
+  - finance
+tags:
+  - banking
+  - institutions
+  - middle-office
+  - operations
+---
+
+Banks are federations of specialized teams tied together by shared data, controls, and regulation.
+
+## Functional Layers
+
+- **Front office**: sales, trading, origination.
+- **Middle office**: risk, controls, limit monitoring.
+- **Back office**: settlement, reconciliation, confirmations.
+- **Treasury and finance**: funding, liquidity, ledger, reporting.
+
+## Engineering Implications
+
+- The same trade needs multiple validated views.
+- Golden-source reference data is non-negotiable.
+- Entitlements and audit trails must be first-class.
+- Workflow tooling is as important as analytics.
+
+## Regulatory/Control Themes
+
+- Data lineage and model governance.
+- Segregation of duties.
+- Exception management and break resolution.
+
+## References
+
+- [Basel Committee Publications](https://www.bis.org/bcbs/publ/)
+- [OCC: Risk Management Guidance](https://www.occ.treas.gov/)
+- [Federal Reserve Supervision and Regulation](https://www.federalreserve.gov/supervisionreg.htm)
+
+## Best Books to Read
+
+- *The Banker's Handbook* — Wouter de Ploey et al.
+- *International Banking* — Robert Grosse, Luiz R. Mesquita
+- *Risk Management in Banking* — Joël Bessis

--- a/_posts/2026-03-21-corporate-banking-systems.md
+++ b/_posts/2026-03-21-corporate-banking-systems.md
@@ -1,0 +1,47 @@
+---
+layout: single
+title: "Corporate Banking Systems: Loans, Facilities, and Controls"
+date: 2026-03-21 09:00:00 +0800
+permalink: /finance/2026/03/21/corporate-banking-systems/
+categories:
+  - finance
+tags:
+  - corporate-banking
+  - loans
+  - facilities
+  - credit-risk
+---
+
+Corporate banking platforms handle long-lived relationships, complex limits, and strict operational controls.
+
+## Domain Model Essentials
+
+- **Client hierarchy**: parent/subsidiary and obligor mapping.
+- **Facilities**: committed/uncommitted, utilization and headroom.
+- **Loans**: drawdown, repayment schedules, interest accrual.
+- **Collateral**: eligibility, haircut, valuation refresh.
+
+## Platform Requirements
+
+- End-to-end lifecycle state machine.
+- Complete audit history for every decision/action.
+- Covenant monitoring with automated triggers.
+- Reconciliation across source systems and finance ledgers.
+
+## Integration Patterns
+
+- Event-driven updates for exposure and utilization.
+- Batch + streaming coexistence for reporting and intraday views.
+- Contract-driven APIs for product and risk engines.
+
+## References
+
+- [IFC SME Banking Knowledge Guide](https://www.ifc.org/en/what-we-do/sector-expertise/financial-institutions/sme-finance)
+- [World Bank: Financial Infrastructure](https://www.worldbank.org/en/topic/financialsector)
+- [Loan Syndications and Trading Association (LSTA)](https://www.lsta.org/)
+
+## Best Books to Read
+
+- *The Handbook of Loan Syndications and Trading* — LSTA contributors
+- *Corporate Banking* — Brian Coyle
+- *Bank Credit Risk Management* — Donald van Deventer et al.

--- a/_posts/2026-03-22-risk-management-and-trader-dashboards.md
+++ b/_posts/2026-03-22-risk-management-and-trader-dashboards.md
@@ -1,0 +1,46 @@
+---
+layout: single
+title: "Risk Management and Trader Dashboards: From Trades to Decisions"
+date: 2026-03-22 09:00:00 +0800
+permalink: /finance/2026/03/22/risk-management-and-trader-dashboards/
+categories:
+  - finance
+tags:
+  - risk-management
+  - dashboards
+  - traders
+  - pnl
+---
+
+Risk dashboards are decision systems. They must be fast, consistent, and explainable under pressure.
+
+## What Traders and Risk Managers Need
+
+- PnL by desk/book/strategy.
+- Intraday changes with attributable drivers.
+- Limit utilization and breaches.
+- Sensitivities by factor and maturity bucket.
+- Stress and scenario impact views.
+
+## Data-to-Decision Pipeline
+
+`Trades -> Enrichment -> Valuation -> Sensitivities -> Aggregation -> Limits -> Dashboard`
+
+## Engineering Requirements
+
+- Low-latency incremental recalculation.
+- As-of snapshots and replay capability.
+- Idempotent aggregation and deterministic totals.
+- Drill-through from top-line number to individual trades.
+
+## References
+
+- [FRTB Overview (BIS)](https://www.bis.org/bcbs/publ/d457.htm)
+- [CFTC Market Risk Advisory Resources](https://www.cftc.gov/)
+- [IOSCO Risk and Market Reports](https://www.iosco.org/)
+
+## Best Books to Read
+
+- *Value at Risk* — Philippe Jorion
+- *Financial Risk Manager Handbook* — Philippe Jorion
+- *Active Portfolio Management* — Grinold & Kahn


### PR DESCRIPTION
### Motivation
- Provide a coherent software-engineering oriented finance series to teach engineers the domain context needed when building money-moving systems.
- Replace the original welcome copy with a clearer roadmap and framing aimed at engineers rather than a pure memoir-style intro.
- Surface a set of focused posts covering markets, microstructure, financial engineering, banking, corporate systems, and risk dashboards to form the series backbone.

### Description
- Updated the existing overview at `/_posts/2026-02-27-welcome-to-finance.md` to reframe the introduction, rename the section to a `Series Roadmap`, and replace the old article list with direct links to the new finance posts. 
- Added a new foundational post `/_posts/2026-03-17-introduction-to-financial-markets.md` that outlines market structure, pricing, banking roles, corporate banking, risk lineage, and engineering patterns. 
- Added five topical posts with frontmatter and content: `market-microstructure` (`2026-03-18`), `financial-engineering-for-builders` (`2026-03-19`), `banking-and-financial-institutions` (`2026-03-20`), `corporate-banking-systems` (`2026-03-21`), and `risk-management-and-trader-dashboards` (`2026-03-22`), each including practical notes, references, and recommended readings. 

### Testing
- Validated the site build locally using `jekyll build` to ensure the new Markdown posts and updated welcome page render without build errors, and the build succeeded. 
- No automated unit tests were applicable to content changes beyond the site build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116cda0ff883239a55547bfbf70d3d)