### PR TITLE
Add detailed posts for AI and Blockchain series and update welcome pages with numbered roadmap

### DIFF
--- a/_posts/2026-02-27-welcome-to-ai.md
+++ b/_posts/2026-02-27-welcome-to-ai.md
@@ -31,5 +31,8 @@ I'll be writing from that perspective: practical, grounded, and honest about the
 
 ## Articles in This Series
 
-- [How Andrew Ng's Courses Changed the Way I Think About AI]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng.html)
+- [1. How Andrew Ng's Courses Changed the Way I Think About AI]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng.html)
+- [2. MLOps and Evaluation: From Notebook Models to Reliable Production]({{ site.baseurl }}/ai/2026/04/04/mlops-and-evaluation.html)
+- [3. LLM Systems and RAG: Building Useful AI Beyond Prompt Demos]({{ site.baseurl }}/ai/2026/04/05/llm-systems-and-rag.html)
+- [4. AI Agents in Production: Planning, Tool Use, and Safety Boundaries]({{ site.baseurl }}/ai/2026/04/06/ai-agents-tool-use.html)
 - [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-02-27-welcome-to-blockchain.md
+++ b/_posts/2026-02-27-welcome-to-blockchain.md
@@ -30,5 +30,8 @@ This series is for developers who want to understand what's actually happening u
 
 ## Articles in This Series
 
-- [Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction.html)
+- [1. Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction.html)
+- [2. Smart Contracts and the EVM: How Ethereum Actually Executes Code]({{ site.baseurl }}/blockchain/2026/04/01/smart-contracts-and-evm.html)
+- [3. DeFi Protocol Design: AMMs, Lending, and On-Chain Risk]({{ site.baseurl }}/blockchain/2026/04/02/defi-protocol-design.html)
+- [4. Blockchain Scalability: Layer 2 Rollups, Data Availability, and Trade-offs]({{ site.baseurl }}/blockchain/2026/04/03/blockchain-scalability-and-rollups.html)
 - [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)

--- a/_posts/2026-04-01-smart-contracts-and-evm.md
+++ b/_posts/2026-04-01-smart-contracts-and-evm.md
@@ -1,0 +1,119 @@
+---
+layout: single
+title: "Smart Contracts and the EVM: How Ethereum Actually Executes Code"
+date: 2026-04-01 10:00:00 +0800
+categories:
+  - blockchain
+tags:
+  - smart-contracts
+  - ethereum
+  - evm
+  - solidity
+  - gas
+---
+
+This is Post 2 in the [Blockchain Series]({{ site.baseurl }}/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction.html) covered cryptography, consensus, and the trustless ledger.
+
+Smart contracts are not "magic legal contracts". They are deterministic programs executed by a global, adversarially replicated computer. If your logic is wrong, the network will execute the wrong logic *perfectly*.
+
+---
+
+## 1) The Contract Mental Model: A Persistent State Machine
+
+At core, a smart contract is:
+
+`new_state = f(old_state, input)`
+
+Where:
+- `old_state` is on-chain storage,
+- `input` is calldata from a transaction,
+- `f` is EVM bytecode,
+- `new_state` must be reproducible by every validator.
+
+This is why determinism is non-negotiable: contracts cannot read your local clock, fetch random web APIs, or depend on host machine behavior.
+
+## 2) How a Transaction Becomes State
+
+```text
+User signs tx
+→ tx enters mempool
+→ proposer/validator includes tx in block
+→ all full nodes execute same bytecode
+→ if valid, global state root changes
+```
+
+If one node computes a different result, that node is wrong and falls out of consensus.
+
+## 3) EVM Internals That Matter in Real Design
+
+- **Stack**: 256-bit word stack machine (opcode-level execution).
+- **Memory**: transient per-call workspace (cheap, cleared after call).
+- **Storage**: persistent key-value store (expensive and state-rent sensitive).
+- **Calldata**: immutable input payload from caller (cheap to read).
+- **Logs/Events**: indexable outputs for off-chain consumers.
+
+Most gas optimization comes down to reducing expensive storage writes and unnecessary external calls.
+
+## 4) Gas, Fees, and Failure Modes
+
+Gas is Ethereum's anti-abuse metering system.
+
+- Every opcode has a gas cost.
+- Sender sets gas limit and fee parameters.
+- Out-of-gas reverts state changes in the call frame.
+- Gas spent is still paid, even on revert.
+
+Common production failures:
+1. Underestimating gas in loops over unbounded arrays.
+2. Writing storage repeatedly instead of caching in memory.
+3. Designing admin or payout flows that become too expensive under high state growth.
+
+## 5) Security Patterns You Should Treat as Defaults
+
+- **Checks → Effects → Interactions** ordering.
+- **Pull payment** over push payment.
+- **Reentrancy guard** on sensitive paths.
+- **Access control** with explicit roles.
+- **Pause/circuit breaker** for emergency response.
+- **Invariant-focused tests** (not just happy path unit tests).
+
+```solidity
+contract Vault {
+    mapping(address => uint256) public balances;
+
+    function deposit() external payable {
+        balances[msg.sender] += msg.value;
+    }
+
+    function withdraw(uint256 amount) external {
+        require(balances[msg.sender] >= amount, "insufficient");
+        balances[msg.sender] -= amount; // Effects first
+        (bool ok, ) = msg.sender.call{value: amount}(""); // Interaction after
+        require(ok, "transfer failed");
+    }
+}
+```
+
+## 6) Build Workflow for Serious Teams
+
+1. Model protocol invariants before coding.
+2. Implement minimal surface area contracts.
+3. Add fuzzing + property tests.
+4. Run static analyzers and symbolic checks.
+5. Audit before mainnet deployment.
+6. Ship with monitoring + incident runbooks.
+
+## References
+
+- Ethereum docs (EVM, execution, gas): https://ethereum.org/en/developers/docs/
+- Solidity docs: https://docs.soliditylang.org/
+- Gavin Wood, *Ethereum Yellow Paper*: https://ethereum.github.io/yellowpaper/paper.pdf
+- ConsenSys Smart Contract Best Practices: https://consensysdiligence.github.io/smart-contract-best-practices/
+
+## Best Books
+
+- Andreas M. Antonopoulos & Gavin Wood, *Mastering Ethereum*.
+- Chris Dannen, *Introducing Ethereum and Solidity*.
+- Narayanan et al., *Bitcoin and Cryptocurrency Technologies* (foundations).
+
+Next: [DeFi Protocol Design: AMMs, Lending, and On-Chain Risk]({{ site.baseurl }}/blockchain/2026/04/02/defi-protocol-design.html).

--- a/_posts/2026-04-02-defi-protocol-design.md
+++ b/_posts/2026-04-02-defi-protocol-design.md
@@ -1,0 +1,86 @@
+---
+layout: single
+title: "DeFi Protocol Design: AMMs, Lending, and On-Chain Risk"
+date: 2026-04-02 10:00:00 +0800
+categories:
+  - blockchain
+tags:
+  - defi
+  - amm
+  - lending
+  - risk
+  - tokenomics
+---
+
+This is Post 3 in the [Blockchain Series]({{ site.baseurl }}/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post]({{ site.baseurl }}/blockchain/2026/04/01/smart-contracts-and-evm.html) covered smart contracts and the EVM.
+
+DeFi protocols are financial systems made of code, incentives, and adversarial game theory. Good protocol design is not just "can it run", but "can it survive volatility, manipulation, and user panic".
+
+## 1) AMMs and Price Formation
+
+Constant-product AMMs use:
+
+`x * y = k`
+
+A swap changes reserves and implied price. Large trades relative to pool depth create slippage. LPs earn fees but carry impermanent loss risk.
+
+Design implications:
+- More liquidity lowers slippage.
+- Fee tiers affect route choice and LP behavior.
+- Oracle-dependent protocols should account for AMM price manipulation windows.
+
+## 2) Lending: Collateral, Liquidations, Solvency
+
+Lending protocols typically require over-collateralization.
+
+Key controls:
+- **LTV** (loan-to-value),
+- **Liquidation threshold**,
+- **Close factor**,
+- **Liquidation bonus**,
+- **Oracle staleness / heartbeat checks**.
+
+Risk engine quality determines whether the system degrades gracefully or collapses during market stress.
+
+## 3) Oracle Risk Is Protocol Risk
+
+If your protocol reads manipulated or stale prices, all other safeguards are weakened.
+
+Mitigations:
+1. Decentralized oracle networks.
+2. TWAP or medianization strategies.
+3. Circuit breakers when deviation exceeds threshold.
+4. Multi-source fallback logic.
+
+## 4) Governance and Upgrade Risk
+
+Even perfect contract logic can be compromised by governance capture.
+
+Best practices:
+- Timelocks on privileged actions.
+- Multi-sig and role separation.
+- Parameter bounds at contract level.
+- Transparent on-chain governance logs.
+
+## 5) Incident Response and Monitoring
+
+Production DeFi needs:
+- real-time health factor and liquidation dashboards,
+- anomaly detection for oracle and liquidity shocks,
+- runbooks for pause/degrade/recover,
+- postmortem culture and parameter hardening.
+
+## References
+
+- Uniswap v2 whitepaper: https://uniswap.org/whitepaper.pdf
+- Aave docs: https://docs.aave.com/
+- Chainlink docs: https://docs.chain.link/
+- Gauntlet research (risk frameworks): https://www.gauntlet.xyz/resources
+
+## Best Books
+
+- Campbell R. Harvey, Ashwin Ramachandran, Joey Santoro, *DeFi and the Future of Finance*.
+- Andreas M. Antonopoulos, *Mastering Bitcoin*.
+- Chris Burniske & Jack Tatar, *Cryptoassets*.
+
+Next: [Blockchain Scalability: Layer 2 Rollups, Data Availability, and Trade-offs]({{ site.baseurl }}/blockchain/2026/04/03/blockchain-scalability-and-rollups.html).

--- a/_posts/2026-04-03-blockchain-scalability-and-rollups.md
+++ b/_posts/2026-04-03-blockchain-scalability-and-rollups.md
@@ -1,0 +1,68 @@
+---
+layout: single
+title: "Blockchain Scalability: Layer 2 Rollups, Data Availability, and Trade-offs"
+date: 2026-04-03 10:00:00 +0800
+categories:
+  - blockchain
+tags:
+  - layer2
+  - rollups
+  - scalability
+  - data-availability
+---
+
+This is Post 4 in the [Blockchain Series]({{ site.baseurl }}/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post]({{ site.baseurl }}/blockchain/2026/04/02/defi-protocol-design.html) covered DeFi protocol design.
+
+Scalability is not one knob. It is a three-way trade-off between throughput, security assumptions, and decentralization pressure.
+
+## 1) Why L2 Exists
+
+L1 chains prioritize security and censorship resistance, which limits raw throughput. L2s move most execution off L1 while using L1 as settlement and dispute layer.
+
+## 2) Optimistic vs ZK Rollups
+
+### Optimistic Rollups
+- Assume state transitions are valid by default.
+- Fraud proofs challenge invalid transitions.
+- Withdrawal latency depends on challenge window.
+
+### ZK Rollups
+- Publish validity proofs (SNARK/STARK) to L1.
+- Faster cryptographic finality.
+- Prover complexity and cost are non-trivial engineering constraints.
+
+## 3) Data Availability (DA) Is Central
+
+A valid proof without accessible data is not enough for trust-minimized reconstruction.
+
+DA options:
+- On-chain calldata / blobs.
+- Validium/volition models (lower cost, added trust assumptions).
+- Modular DA layers (performance with architecture complexity).
+
+## 4) Practical Architecture Selection
+
+Choose based on workload:
+- Consumer payments/gaming: low fees, high throughput, UX-first.
+- Institutional settlement: stronger finality + auditability.
+- DeFi composability: EVM equivalence and bridge assumptions matter.
+
+## 5) Hidden Costs Teams Underestimate
+
+1. Bridge and messaging security.
+2. Sequencer decentralization roadmap.
+3. State growth and archival burden.
+4. Operational complexity across many chains.
+
+## References
+
+- OP Stack docs: https://docs.optimism.io/
+- Arbitrum docs: https://docs.arbitrum.io/
+- zkSync docs: https://docs.zksync.io/
+- Ethereum roadmap discussions: https://ethereum-magicians.org/
+
+## Best Books
+
+- Andreas M. Antonopoulos & Gavin Wood, *Mastering Ethereum*.
+- Narayanan et al., *Bitcoin and Cryptocurrency Technologies*.
+- Martin Kleppmann, *Designing Data-Intensive Applications* (systems trade-offs).

--- a/_posts/2026-04-04-mlops-and-evaluation.md
+++ b/_posts/2026-04-04-mlops-and-evaluation.md
@@ -1,0 +1,66 @@
+---
+layout: single
+title: "MLOps and Evaluation: From Notebook Models to Reliable Production"
+date: 2026-04-04 10:00:00 +0800
+categories:
+  - ai
+tags:
+  - mlops
+  - evaluation
+  - monitoring
+  - deployment
+---
+
+This is Post 3 in the [AI Series]({{ site.baseurl }}/ai/2026/02/27/welcome-to-ai.html). The [previous post]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng.html) covered learning foundations.
+
+Shipping ML is primarily an operations problem. Most failures are not model architecture failures; they are data quality, evaluation leakage, and runtime reliability failures.
+
+## 1) The Production Lifecycle
+
+1. Data contracts + ownership
+2. Feature pipelines with reproducibility
+3. Training with lineage and experiment tracking
+4. Offline evaluation (incl. subgroup metrics)
+5. Safe rollout (shadow/canary)
+6. Monitoring + drift detection + retraining policy
+
+## 2) Evaluation Beyond Accuracy
+
+Use metrics aligned to business and risk:
+- Precision/recall/F1 for imbalance.
+- Calibration (Brier/expected calibration error).
+- Ranking metrics when ordering matters.
+- Latency, p95/p99, and cost-per-inference.
+- KPI uplift and downstream operational impact.
+
+## 3) Drift and Silent Failure
+
+Models degrade when:
+- feature distribution shifts,
+- label definition changes,
+- user behavior evolves,
+- upstream data contracts break.
+
+Treat monitoring as first-class product engineering, not a dashboard afterthought.
+
+## 4) Rollout Safety Patterns
+
+- Shadow mode before user impact.
+- Canary with auto-rollback thresholds.
+- Versioned features + model registry.
+- Human-in-the-loop for high-stakes decisions.
+
+## References
+
+- Google, *Rules of ML*: https://developers.google.com/machine-learning/guides/rules-of-ml
+- Sculley et al., *Hidden Technical Debt in ML Systems*: https://papers.nips.cc/paper_files/paper/2015/file/86df7dcfd896fcaf2674f757a2463eba-Paper.pdf
+- Evidently docs: https://docs.evidentlyai.com/
+- MLflow docs: https://mlflow.org/docs/latest/index.html
+
+## Best Books
+
+- Chip Huyen, *Designing Machine Learning Systems*.
+- Mark Treveil et al., *Introducing MLOps*.
+- Emmanuel Ameisen, *Building Machine Learning Powered Applications*.
+
+Next: [LLM Systems and RAG: Building Useful AI Beyond Prompt Demos]({{ site.baseurl }}/ai/2026/04/05/llm-systems-and-rag.html).

--- a/_posts/2026-04-05-llm-systems-and-rag.md
+++ b/_posts/2026-04-05-llm-systems-and-rag.md
@@ -1,0 +1,68 @@
+---
+layout: single
+title: "LLM Systems and RAG: Building Useful AI Beyond Prompt Demos"
+date: 2026-04-05 10:00:00 +0800
+categories:
+  - ai
+tags:
+  - llm
+  - rag
+  - embeddings
+  - vector-database
+  - agents
+---
+
+This is Post 4 in the [AI Series]({{ site.baseurl }}/ai/2026/02/27/welcome-to-ai.html). The [previous post]({{ site.baseurl }}/ai/2026/04/04/mlops-and-evaluation.html) covered MLOps and evaluation.
+
+RAG became the default architecture because base models are general but not naturally grounded in proprietary or rapidly changing knowledge.
+
+## 1) Canonical RAG Pipeline
+
+1. Ingest and normalize documents.
+2. Chunk with overlap tuned to use case.
+3. Generate embeddings.
+4. Index in vector DB with metadata.
+5. Retrieve + rerank.
+6. Compose grounded prompt and generate.
+7. Enforce citation/attribution in output.
+
+## 2) Design Decisions That Actually Move Quality
+
+- Chunk strategy (semantic vs fixed length).
+- Metadata design (time, source, permission scope).
+- Hybrid retrieval (sparse + dense).
+- Reranking quality vs latency budget.
+- Prompt template with explicit abstention behavior.
+
+## 3) Evaluation Framework
+
+Evaluate with task-specific sets:
+- Retrieval hit rate / nDCG.
+- Faithfulness and groundedness.
+- Hallucination rate.
+- Citation correctness.
+- End-to-end latency and cost.
+
+No eval set means no engineering signal.
+
+## 4) Guardrails for Real Deployments
+
+- Structured outputs (JSON schema).
+- Tool permissions and sandboxed actions.
+- PII and compliance filters.
+- Fallback behavior when confidence is low.
+
+## References
+
+- Lewis et al., RAG paper: https://arxiv.org/abs/2005.11401
+- OpenAI Cookbook: https://cookbook.openai.com/
+- LangChain RAG concepts: https://python.langchain.com/docs/concepts/rag/
+- LlamaIndex docs: https://docs.llamaindex.ai/
+
+## Best Books
+
+- Jurafsky & Martin, *Speech and Language Processing*.
+- Chip Huyen, *AI Engineering*.
+- O'Reilly, *Designing Large Language Model Applications*.
+
+Next: [AI Agents in Production: Planning, Tool Use, and Safety Boundaries]({{ site.baseurl }}/ai/2026/04/06/ai-agents-tool-use.html).

--- a/_posts/2026-04-06-ai-agents-tool-use.md
+++ b/_posts/2026-04-06-ai-agents-tool-use.md
@@ -1,0 +1,75 @@
+---
+layout: single
+title: "AI Agents in Production: Planning, Tool Use, and Safety Boundaries"
+date: 2026-04-06 10:00:00 +0800
+categories:
+  - ai
+tags:
+  - ai-agents
+  - tool-use
+  - planning
+  - safety
+---
+
+This is Post 5 in the [AI Series]({{ site.baseurl }}/ai/2026/02/27/welcome-to-ai.html). The [previous post]({{ site.baseurl }}/ai/2026/04/05/llm-systems-and-rag.html) covered LLM systems and RAG.
+
+Agent systems are not just bigger prompts; they are control systems with feedback loops, external actions, and safety boundaries.
+
+## 1) Agent Loop: Plan → Act → Observe → Adapt
+
+A production agent typically:
+1. decomposes a goal,
+2. selects tools,
+3. executes actions,
+4. evaluates results,
+5. retries, reroutes, or escalates.
+
+This loop is where value appears—and where risk appears.
+
+## 2) Core Architecture Blocks
+
+- **Planner**: task decomposition and prioritization.
+- **Executor**: function/tool invocation.
+- **Memory**: short-term context + durable task state.
+- **Evaluator/Critic**: correctness and policy checks.
+- **Policy Engine**: permission and compliance decisions.
+
+## 3) Failure Modes in the Wild
+
+- Tool misuse from weak schema contracts.
+- Infinite loops from weak termination conditions.
+- Hallucinated tool outputs accepted as truth.
+- Privilege escalation via prompt injection.
+
+## 4) Non-Negotiable Safety Controls
+
+- Least-privilege credentials per tool.
+- Confirmation gates for irreversible actions.
+- Sandboxed execution environments.
+- Immutable audit logs and replayability.
+- Output validation against typed schemas.
+- Human handoff for high-impact decisions.
+
+## 5) Evaluation for Agentic Systems
+
+Measure:
+- task completion rate,
+- step efficiency,
+- tool-call accuracy,
+- policy violation rate,
+- time-to-recovery after failure.
+
+Agent quality is behavioral reliability over many trajectories, not one benchmark score.
+
+## References
+
+- ReAct paper: https://arxiv.org/abs/2210.03629
+- Toolformer paper: https://arxiv.org/abs/2302.04761
+- Anthropic engineering posts: https://www.anthropic.com/engineering
+- OpenAI Agents guide: https://platform.openai.com/docs/guides/agents
+
+## Best Books
+
+- Chip Huyen, *AI Engineering*.
+- Martin Kleppmann, *Designing Data-Intensive Applications*.
+- Ronald T. Kneusel, *Practical Deep Learning*.


### PR DESCRIPTION
### Motivation

- Provide concrete, follow-up posts for both the AI and Blockchain series so readers have a clear roadmap of upcoming technical deep dives. 
- Surface practical engineering guidance (MLOps, LLM systems, agents, EVM internals, DeFi, rollups) as companion posts to the introductory welcome pages. 
- Make the series indices explicit and easier to navigate by enumerating and ordering the posts in the welcome pages. 

### Description

- Added new blockchain posts: `2026-04-01-smart-contracts-and-evm.md`, `2026-04-02-defi-protocol-design.md`, and `2026-04-03-blockchain-scalability-and-rollups.md`, each with front matter, structured sections, and references. 
- Added new AI posts: `2026-04-04-mlops-and-evaluation.md`, `2026-04-05-llm-systems-and-rag.md`, and `2026-04-06-ai-agents-tool-use.md`, each with front matter, structured guidance, and next-post links. 
- Updated the two series landing posts `2026-02-27-welcome-to-ai.md` and `2026-02-27-welcome-to-blockchain.md` to enumerate the series items with numbered links pointing to the new posts. 

### Testing

- Performed a site build with `jekyll build` to validate front matter and basic Markdown rendering, and the build completed successfully. 
- No automated unit tests were applicable to the content changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119b7e7e048323844de6659b284db6)