### PR TITLE
Normalize internal links to pretty permalinks and adjust series post references

### DIFF
--- a/_posts/2026-02-27-welcome-to-ai.md
+++ b/_posts/2026-02-27-welcome-to-ai.md
@@ -31,8 +31,8 @@ I'll be writing from that perspective: practical, grounded, and honest about the
 
 ## Articles in This Series
 
-- [1. How Andrew Ng's Courses Changed the Way I Think About AI]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng.html)
-- [2. MLOps and Evaluation: From Notebook Models to Reliable Production]({{ site.baseurl }}/ai/2026/04/04/mlops-and-evaluation.html)
-- [3. LLM Systems and RAG: Building Useful AI Beyond Prompt Demos]({{ site.baseurl }}/ai/2026/04/05/llm-systems-and-rag.html)
-- [4. AI Agents in Production: Planning, Tool Use, and Safety Boundaries]({{ site.baseurl }}/ai/2026/04/06/ai-agents-tool-use.html)
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [1. How Andrew Ng's Courses Changed the Way I Think About AI]({{ site.baseurl }}/ai/2026/02/27/learning-ml-andrew-ng/)
+- [2. MLOps and Evaluation: From Notebook Models to Reliable Production]({{ site.baseurl }}/ai/2026/04/04/mlops-and-evaluation/)
+- [3. LLM Systems and RAG: Building Useful AI Beyond Prompt Demos]({{ site.baseurl }}/ai/2026/04/05/llm-systems-and-rag/)
+- [4. AI Agents in Production: Planning, Tool Use, and Safety Boundaries]({{ site.baseurl }}/ai/2026/04/06/ai-agents-tool-use/)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises/)

--- a/_posts/2026-02-27-welcome-to-blockchain.md
+++ b/_posts/2026-02-27-welcome-to-blockchain.md
@@ -30,8 +30,8 @@ This series is for developers who want to understand what's actually happening u
 
 ## Articles in This Series
 
-- [1. Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction.html)
-- [2. Smart Contracts and the EVM: How Ethereum Actually Executes Code]({{ site.baseurl }}/blockchain/2026/04/01/smart-contracts-and-evm.html)
-- [3. DeFi Protocol Design: AMMs, Lending, and On-Chain Risk]({{ site.baseurl }}/blockchain/2026/04/02/defi-protocol-design.html)
-- [4. Blockchain Scalability: Layer 2 Rollups, Data Availability, and Trade-offs]({{ site.baseurl }}/blockchain/2026/04/03/blockchain-scalability-and-rollups.html)
-- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises.html)
+- [1. Blockchain From First Principles: Cryptography, Consensus, and the Trustless Ledger]({{ site.baseurl }}/blockchain/2026/02/27/blockchain-introduction/)
+- [2. Smart Contracts and the EVM: How Ethereum Actually Executes Code]({{ site.baseurl }}/blockchain/2026/04/01/smart-contracts-and-evm/)
+- [3. DeFi Protocol Design: AMMs, Lending, and On-Chain Risk]({{ site.baseurl }}/blockchain/2026/04/02/defi-protocol-design/)
+- [4. Blockchain Scalability: Layer 2 Rollups, Data Availability, and Trade-offs]({{ site.baseurl }}/blockchain/2026/04/03/blockchain-scalability-and-rollups/)
+- [AI and Blockchain — The Promises, The Fear, and What People Who Build Them Actually Know]({{ site.baseurl }}/ai/blockchain/2026/02/27/ai-blockchain-promises/)

--- a/_posts/2026-04-01-smart-contracts-and-evm.md
+++ b/_posts/2026-04-01-smart-contracts-and-evm.md
@@ -12,7 +12,7 @@ tags:
   - gas
 ---
 
-This is Post 2 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post](/blockchain/2026/02/27/blockchain-introduction.html) covered blockchain fundamentals.
+This is Post 2 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain/). The [previous post](/blockchain/2026/02/27/blockchain-introduction/) covered blockchain fundamentals.
 
 ## Why Smart Contracts Matter
 

--- a/_posts/2026-04-02-defi-protocol-design.md
+++ b/_posts/2026-04-02-defi-protocol-design.md
@@ -12,7 +12,7 @@ tags:
   - tokenomics
 ---
 
-This is Post 3 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post](/blockchain/2026/04/01/smart-contracts-and-evm.html) covered smart contracts and the EVM.
+This is Post 3 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain/). The [previous post](/blockchain/2026/04/01/smart-contracts-and-evm/) covered smart contracts and the EVM.
 
 ## AMMs: Market Making in Code
 

--- a/_posts/2026-04-03-blockchain-scalability-and-rollups.md
+++ b/_posts/2026-04-03-blockchain-scalability-and-rollups.md
@@ -11,7 +11,7 @@ tags:
   - data-availability
 ---
 
-This is Post 4 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain.html). The [previous post](/blockchain/2026/04/02/defi-protocol-design.html) covered DeFi protocol design.
+This is Post 4 in the [Blockchain Series](/blockchain/2026/02/27/welcome-to-blockchain/). The [previous post](/blockchain/2026/04/02/defi-protocol-design/) covered DeFi protocol design.
 
 ## Why Layer 2 Exists
 

--- a/_posts/2026-04-04-mlops-and-evaluation.md
+++ b/_posts/2026-04-04-mlops-and-evaluation.md
@@ -11,7 +11,7 @@ tags:
   - deployment
 ---
 
-This is Post 3 in the [AI Series](/ai/2026/02/27/welcome-to-ai.html). The [previous post](/ai/2026/02/27/learning-ml-andrew-ng.html) covered the learning journey and foundations.
+This is Post 2 in the [AI Series](/ai/2026/02/27/welcome-to-ai/). The [previous post](/ai/2026/02/27/learning-ml-andrew-ng/) covered the learning journey and foundations.
 
 ## The Real Problem: Reliability, Not Demos
 

--- a/_posts/2026-04-05-llm-systems-and-rag.md
+++ b/_posts/2026-04-05-llm-systems-and-rag.md
@@ -12,7 +12,7 @@ tags:
   - agents
 ---
 
-This is Post 4 in the [AI Series](/ai/2026/02/27/welcome-to-ai.html). The [previous post](/ai/2026/04/04/mlops-and-evaluation.html) covered MLOps and evaluation.
+This is Post 3 in the [AI Series](/ai/2026/02/27/welcome-to-ai/). The [previous post](/ai/2026/04/04/mlops-and-evaluation/) covered MLOps and evaluation.
 
 ## Why RAG Became Default
 

--- a/_posts/2026-04-06-ai-agents-tool-use.md
+++ b/_posts/2026-04-06-ai-agents-tool-use.md
@@ -11,7 +11,7 @@ tags:
   - safety
 ---
 
-This is Post 5 in the [AI Series](/ai/2026/02/27/welcome-to-ai.html). The [previous post](/ai/2026/04/05/llm-systems-and-rag.html) covered LLM system design and RAG.
+This is Post 4 in the [AI Series](/ai/2026/02/27/welcome-to-ai/). The [previous post](/ai/2026/04/05/llm-systems-and-rag/) covered LLM system design and RAG.
 
 ## What Makes an Agent Different
 


### PR DESCRIPTION
### Motivation
- Normalize internal URLs to directory-style (pretty) permalinks and make series references consistent across AI and Blockchain posts.

### Description
- Replace `.html` style internal links with trailing-slash directory permalinks in welcome and series posts.
- Update the "This is Post X in the [Series]" lines to reflect the corrected post numbers for several AI and Blockchain posts.
- Apply the link/numbering changes across `welcome-to-ai.md`, `welcome-to-blockchain.md`, `smart-contracts-and-evm.md`, `defi-protocol-design.md`, `blockchain-scalability-and-rollups.md`, `mlops-and-evaluation.md`, `llm-systems-and-rag.md`, and `ai-agents-tool-use.md`.

### Testing
- Built the site locally with `jekyll build` to verify no build errors and confirm templates render; the build succeeded.
- Ran an HTML link checker (`htmlproofer`) against the output to validate internal links; the checker reported no broken internal links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122ce12adc8323b85ae6586a229d83)